### PR TITLE
Eigen-based sterile oscillation calculator

### DIFF
--- a/OscLib/IOscCalcSterile.cxx
+++ b/OscLib/IOscCalcSterile.cxx
@@ -1,0 +1,82 @@
+#include "OscLib/IOscCalcSterile.h"
+
+#include <iostream>
+
+namespace osc
+{
+  //---------------------------------------------------------------------------
+  void IOscCalcSterile::SetDmsq21(const double&)
+  {
+    std::cerr << "Must use SetDm!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void IOscCalcSterile::SetDmsq32(const double&)
+  {
+    std::cerr << "Must use SetDm!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void IOscCalcSterile::SetTh12(const double&)
+  {
+    std::cerr << "Must use SetAngle!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void IOscCalcSterile::SetTh13(const double&)
+  {
+    std::cerr << "Must use SetAngle!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void IOscCalcSterile::SetTh23(const double&)
+  {
+    std::cerr << "Must use SetAngle!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void IOscCalcSterile::SetdCP(const double&)
+  {
+    std::cerr << "Must use SetDelta!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  double OscCalcSterileTrivial::P(int, int, double)
+  {
+    return 1;
+  }
+
+  //---------------------------------------------------------------------------
+  IOscCalcAdjustable* OscCalcSterileTrivial::Copy() const
+  {
+    return new OscCalcSterileTrivial();
+  }
+
+  //---------------------------------------------------------------------------
+  const IOscCalcSterile* DowncastToSterile(const IOscCalc* calc)
+  {
+    const IOscCalcSterile* calc_sterile
+            = dynamic_cast<const IOscCalcSterile*>(calc);
+    if(calc_sterile) return calc_sterile;
+    std::cout << "Input calculator was not of type IOscCalcSterile." << std::endl;
+    return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
+  }
+
+  //---------------------------------------------------------------------------
+  IOscCalcSterile* DowncastToSterile(IOscCalc* calc)
+  {
+    IOscCalcSterile* calc_sterile
+            = dynamic_cast<IOscCalcSterile*>(calc);
+    if (calc_sterile) return calc_sterile;
+    std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
+    return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
+  }
+
+}
+

--- a/OscLib/IOscCalcSterile.cxx
+++ b/OscLib/IOscCalcSterile.cxx
@@ -59,22 +59,24 @@ namespace osc
   }
 
   //---------------------------------------------------------------------------
-  const IOscCalcSterile* DowncastToSterile(const IOscCalc* calc)
+  const IOscCalcSterile* DowncastToSterile(const IOscCalc* calc, bool quiet)
   {
     const IOscCalcSterile* calc_sterile
             = dynamic_cast<const IOscCalcSterile*>(calc);
     if(calc_sterile) return calc_sterile;
-    std::cout << "Input calculator was not of type IOscCalcSterile." << std::endl;
+    if (!quiet)
+      std::cout << "Input calculator was not of type IOscCalcSterile." << std::endl;
     return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
   }
 
   //---------------------------------------------------------------------------
-  IOscCalcSterile* DowncastToSterile(IOscCalc* calc)
+  IOscCalcSterile* DowncastToSterile(IOscCalc* calc, bool quiet)
   {
     IOscCalcSterile* calc_sterile
             = dynamic_cast<IOscCalcSterile*>(calc);
     if (calc_sterile) return calc_sterile;
-    std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
+    if (!quiet)
+      std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
     return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
   }
 

--- a/OscLib/IOscCalcSterile.h
+++ b/OscLib/IOscCalcSterile.h
@@ -14,6 +14,11 @@
 
 namespace osc
 {
+  /// \brief base class for sterile oscillation calculators
+  /// In the context of a sterile oscillation calculator, a PDG code
+  /// of zero corresponds to the survival probability for an active
+  /// neutrino, ie. the sum of the oscillation probabilities for the
+  /// three active neutrino states.
   class IOscCalcSterile: public IOscCalcAdjustable
   {
   public:
@@ -46,6 +51,7 @@ namespace osc
 
   };
 
+  /// \brief version of OscCalcSterile that always returns probability of 1
   class OscCalcSterileTrivial: public IOscCalcSterile
   {
   public:
@@ -66,10 +72,8 @@ namespace osc
     virtual double GetDelta(int, int) const override { return 0; };
   };
 
-  /// \brief version of OscCalcSterile that always returns probability of 1
-
-  const IOscCalcSterile* DowncastToSterile(const IOscCalc* calc);
-  IOscCalcSterile* DowncastToSterile(IOscCalc* calc);
+  const IOscCalcSterile* DowncastToSterile(const IOscCalc* calc, bool quiet=false);
+  IOscCalcSterile* DowncastToSterile(IOscCalc* calc, bool quiet=false);
 
 } // namespace
 

--- a/OscLib/IOscCalcSterile.h
+++ b/OscLib/IOscCalcSterile.h
@@ -1,0 +1,76 @@
+#ifndef OSC_IOSCCALCSTERILE_H
+#define OSC_IOSCCALCSTERILE_H
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// \file IOscCalcSterile.h                                              //
+//                                                                      //
+// Base class for sterile oscillation calculator                        //
+// <jhewes15@fnal.gov>                                                  //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "OscLib/IOscCalc.h"
+
+namespace osc
+{
+  class IOscCalcSterile: public IOscCalcAdjustable
+  {
+  public:
+    virtual ~IOscCalcSterile() {};
+
+    virtual void SetL  (double L  ) override {fDirty = true; fL   = L;}
+    virtual void SetRho(double rho) override {fDirty = true; fRho = rho;}
+
+    virtual void SetAngle(int i, int j, double th)    = 0;
+    virtual void SetDelta(int i, int j, double delta) = 0;
+    virtual void SetDm(int i, double dm)              = 0;
+
+    double GetL()                 const override { return fL; }
+    double GetRho()               const override { return fRho; }
+    virtual double GetDm(int i)           const = 0;
+    virtual double GetAngle(int i, int j) const = 0;
+    virtual double GetDelta(int i, int j) const = 0;
+
+  protected:
+
+    virtual void SetDmsq21(const double& dmsq21) override;
+    virtual void SetDmsq32(const double& dmsq32) override;
+    virtual void SetTh12  (const double& th12  ) override;
+    virtual void SetTh13  (const double& th13  ) override;
+    virtual void SetTh23  (const double& th23  ) override;
+    virtual void SetdCP   (const double& dCP   ) override;
+
+    double fRho; 
+    bool   fDirty;
+
+  };
+
+  class OscCalcSterileTrivial: public IOscCalcSterile
+  {
+  public:
+    using IOscCalcAdjustable::P;
+    OscCalcSterileTrivial() {};
+    virtual ~OscCalcSterileTrivial() {};
+    virtual double P(int, int, double) override;
+
+  private:
+    virtual IOscCalcAdjustable* Copy() const override;
+
+    virtual void SetAngle(int, int, double) override {};
+    virtual void SetDelta(int, int, double) override {};
+    virtual void SetDm(int, double)         override {};
+
+    virtual double GetDm(int)         const override { return 0; };
+    virtual double GetAngle(int, int) const override { return 0; };
+    virtual double GetDelta(int, int) const override { return 0; };
+  };
+
+  /// \brief version of OscCalcSterile that always returns probability of 1
+
+  const IOscCalcSterile* DowncastToSterile(const IOscCalc* calc);
+  IOscCalcSterile* DowncastToSterile(IOscCalc* calc);
+
+} // namespace
+
+#endif

--- a/OscLib/OscCalcPMNSOptEigen.cxx
+++ b/OscLib/OscCalcPMNSOptEigen.cxx
@@ -11,6 +11,15 @@
 
 namespace osc {
 
+  void _sincos(double theta, double & s, double &c)
+  {
+#ifdef __APPLE_CC__
+    __sincos(theta, &s, &c);
+#else
+    sincos(theta, &s, &c);
+#endif
+  }
+
   TMD5* 
   OscCalcPMNSOptEigen::GetParamsHash() const
   {
@@ -43,15 +52,6 @@ namespace osc {
     fLastParams.th13 = fTh13;
     fLastParams.th23 = fTh23;
     fLastParams.deltacp = fdCP;
-  }
-
-  void _sincos(double theta, double & s, double &c)
-  {
-#ifdef __APPLE_CC__
-    __sincos(theta, &s, &c);
-#else
-    sincos(theta, &s, &c);
-#endif
   }
 
   IOscCalcAdjustable * 

--- a/OscLib/OscCalcPMNSOptEigen.h
+++ b/OscLib/OscCalcPMNSOptEigen.h
@@ -70,6 +70,8 @@ namespace osc
     const Eigen::Vector3d values;
   };
 
+  void _sincos(double theta, double & s, double &c);
+
   /// \brief A re-optimized version of \ref OscCalcPMNSOpt
   ///
   /// Uses a faster caching scheme than OscCalcPMNSOpt

--- a/OscLib/OscCalcSterile.cxx
+++ b/OscLib/OscCalcSterile.cxx
@@ -1,9 +1,6 @@
 #include "OscLib/OscCalcSterile.h"
 
 #include <cassert>
-// #include <cstdlib>
-// #include <iostream>
-// #include <iomanip>
 
 namespace osc
 {

--- a/OscLib/OscCalcSterile.cxx
+++ b/OscLib/OscCalcSterile.cxx
@@ -231,7 +231,7 @@ namespace osc
     if (calc_trivial) return calc_trivial; 
     const OscCalcSterile* calc_sterile = dynamic_cast<const OscCalcSterile*>(calc);
     if(calc_sterile) return calc_sterile;
-    else             std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
+    std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
     return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
   }
 
@@ -243,7 +243,7 @@ namespace osc
     if (calc_trivial) return calc_trivial;
     OscCalcSterile* calc_sterile = dynamic_cast<OscCalcSterile*>(calc);
     if(calc_sterile) return calc_sterile;
-    else             std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
+    std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
     return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
   }
 } // namespace

--- a/OscLib/OscCalcSterile.cxx
+++ b/OscLib/OscCalcSterile.cxx
@@ -1,16 +1,17 @@
 #include "OscLib/OscCalcSterile.h"
 
 #include <cassert>
-#include <cstdlib>
-#include <iostream>
-#include <iomanip>
+// #include <cstdlib>
+// #include <iostream>
+// #include <iomanip>
 
 namespace osc
 {
   OscCalcSterile::OscCalcSterile()
-    : fPMNS_Sterile(0), fNFlavors(3), fDirty(true), fPrevE(0), fPrevAnti(0), fPrevFlavBefore(0)
+    : fPMNS_Sterile(0), fNFlavors(3), fPrevE(0), fPrevAnti(0), fPrevFlavBefore(0)
   {
     fPMNS_Sterile = new PMNS_Sterile(fNFlavors);
+    fDirty = true;
   }
 
   //---------------------------------------------------------------------------
@@ -110,48 +111,6 @@ namespace osc
   }
 
   //---------------------------------------------------------------------------
-  void OscCalcSterile::SetDmsq21(const double&)
-  {
-    std::cerr << "Must use SetDm!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterile::SetDmsq32(const double&)
-  {
-    std::cerr << "Must use SetDm!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterile::SetTh12(const double&)
-  {
-    std::cerr << "Must use SetAngle!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterile::SetTh13(const double&)
-  {
-    std::cerr << "Must use SetAngle!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterile::SetTh23(const double&)
-  {
-    std::cerr << "Must use SetAngle!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterile::SetdCP(const double&)
-  {
-    std::cerr << "Must use SetDelta!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
   double OscCalcSterile::P(int flavBefore, int flavAfter, double E)
   {
     const int anti = (flavBefore > 0) ? +1 : -1;
@@ -188,62 +147,4 @@ namespace osc
     else        return fPMNS_Sterile->P(j);
   }
 
-  //---------------------------------------------------------------------------
-  OscCalcSterileTrivial::OscCalcSterileTrivial()
-    : OscCalcSterile()
-    {}
-
-  //---------------------------------------------------------------------------
-  OscCalcSterileTrivial::OscCalcSterileTrivial(
-    const OscCalcSterile& calc)
-    : OscCalcSterileTrivial()
-  {
-    std::vector<double> state = calc.GetState();
-    SetState(state);
-  }
-
-  //---------------------------------------------------------------------------
-  OscCalcSterileTrivial::OscCalcSterileTrivial(
-    const OscCalcSterileTrivial& calc)
-    : OscCalcSterileTrivial()
-  {
-    std::vector<double> state = calc.GetState();
-    SetState(state);
-  }
-
-  //---------------------------------------------------------------------------
-  IOscCalcAdjustable* OscCalcSterileTrivial::Copy() const
-  {
-    return new OscCalcSterileTrivial(*this);
-  }
-
-  //---------------------------------------------------------------------------
-  double OscCalcSterileTrivial::P(int, int, double)
-  {
-    return 1;
-  }
-
-  //---------------------------------------------------------------------------
-  const OscCalcSterile* DowncastToSterile(const IOscCalc* calc)
-  {
-    const OscCalcSterileTrivial* calc_trivial
-            = dynamic_cast<const OscCalcSterileTrivial*>(calc);
-    if (calc_trivial) return calc_trivial; 
-    const OscCalcSterile* calc_sterile = dynamic_cast<const OscCalcSterile*>(calc);
-    if(calc_sterile) return calc_sterile;
-    std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
-    return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
-  }
-
-  //---------------------------------------------------------------------------
-  OscCalcSterile* DowncastToSterile(IOscCalc* calc)
-  {
-    OscCalcSterileTrivial* calc_trivial
-            = dynamic_cast<OscCalcSterileTrivial*>(calc);
-    if (calc_trivial) return calc_trivial;
-    OscCalcSterile* calc_sterile = dynamic_cast<OscCalcSterile*>(calc);
-    if(calc_sterile) return calc_sterile;
-    std::cout << "Input calculator was not of type OscCalcSterile." << std::endl;
-    return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
-  }
 } // namespace

--- a/OscLib/OscCalcSterile.h
+++ b/OscLib/OscCalcSterile.h
@@ -10,7 +10,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "OscLib/IOscCalc.h"
+#include "OscLib/IOscCalcSterile.h"
 #include "OscLib/PMNS_Sterile.h"
 
 #include <vector>
@@ -20,7 +20,7 @@ namespace osc
   /// \brief Adapt the PMNS_Sterile calculator to standard interface
   ///
   /// Adapt the \ref PMNS_Sterile calculator (3+N with matter effects) to standard interface
-  class OscCalcSterile: public IOscCalcAdjustable
+  class OscCalcSterile: public IOscCalcSterile
   {
   public:
     using IOscCalcAdjustable::P;
@@ -31,65 +31,36 @@ namespace osc
     void SetNFlavors(int nflavors);
 
     virtual IOscCalcAdjustable* Copy() const override;
+
+    virtual void SetAngle(int i, int j, double th);
+    virtual void SetDelta(int i, int j, double delta);
+    virtual void SetDm(int i, double dm);
+
+    virtual double GetDm(int i) const override
+      { return fPMNS_Sterile->GetDm(i); }
+    virtual double GetAngle(int i, int j) const override
+      { return fPMNS_Sterile->GetAngle(i, j); }
+    virtual double GetDelta(int i, int j) const override
+      { return fPMNS_Sterile->GetDelta(i, j); }
     
     // if flavAfter == 0, give the active fraction
     virtual double P(int flavBefore, int flavAfter, double E) override;
 
-    virtual void SetL  (double L  ) override {fDirty = true; fL   = L;}
-    virtual void SetRho(double rho) override {fDirty = true; fRho = rho;}
-
-    void SetAngle(int i, int j, double th);
-    void SetDelta(int i, int j, double delta);
-    void SetDm(int i, double dm);
-
     void SetState(std::vector<double> state);
 
     //Getters
-    int    GetNFlavors()          const { return fPMNS_Sterile->GetNFlavors(); }
-    double GetL()                 const override { return fL; }
-    double GetRho()               const override { return fRho; }
-    double GetDm(int i)           const { return fPMNS_Sterile->GetDm(i); }
-    double GetAngle(int i, int j) const { return fPMNS_Sterile->GetAngle(i, j); }
-    double GetDelta(int i, int j) const { return fPMNS_Sterile->GetDelta(i, j); }
+    int GetNFlavors() const { return fPMNS_Sterile->GetNFlavors(); }
     std::vector<double> GetState() const;
     virtual TMD5* GetParamsHash() const override;
 
   protected:
     PMNS_Sterile* fPMNS_Sterile;
 
-    virtual void SetDmsq21(const double& dmsq21) override;
-    virtual void SetDmsq32(const double& dmsq32) override;
-    virtual void SetTh12  (const double& th12  ) override;
-    virtual void SetTh13  (const double& th13  ) override;
-    virtual void SetTh23  (const double& th23  ) override;
-    virtual void SetdCP   (const double& dCP   ) override;
-
     int    fNFlavors;
-    double fRho; 
-    bool   fDirty;
     double fPrevE;
     int    fPrevAnti;
     int    fPrevFlavBefore;
   };
-
-  /// \brief Version of OscCalcSterile that always returns probability of 1
-  class OscCalcSterileTrivial: public OscCalcSterile
-  {
-  public:
-    using IOscCalc::P;
-    OscCalcSterileTrivial();
-    OscCalcSterileTrivial(const OscCalcSterile& calc);
-    OscCalcSterileTrivial(const OscCalcSterileTrivial& calc);
-    virtual ~OscCalcSterileTrivial() {};
-
-    virtual IOscCalcAdjustable* Copy() const override;
-    
-    // Always return 1
-    virtual double P(int flavBefore, int flavAfter, double E) override;
-  };
-
-  const OscCalcSterile* DowncastToSterile(const IOscCalc* calc);
-  OscCalcSterile* DowncastToSterile(IOscCalc* calc);
 
 } // namespace
 

--- a/OscLib/OscCalcSterile.h
+++ b/OscLib/OscCalcSterile.h
@@ -3,10 +3,10 @@
 
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
-// \file OscCalcSterile.h                                         //
+// \file OscCalcSterile.h                                               //
 //                                                                      //
 // Adapt the PMNS_Sterile calculator to standard interface              //
-// <aurisaam@ucmail.uc.edu>						//
+// <aurisaam@ucmail.uc.edu>                                             //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 

--- a/OscLib/OscCalcSterile.h
+++ b/OscLib/OscCalcSterile.h
@@ -32,9 +32,9 @@ namespace osc
 
     virtual IOscCalcAdjustable* Copy() const override;
 
-    virtual void SetAngle(int i, int j, double th);
-    virtual void SetDelta(int i, int j, double delta);
-    virtual void SetDm(int i, double dm);
+    virtual void SetAngle(int i, int j, double th) override;
+    virtual void SetDelta(int i, int j, double delta) override;
+    virtual void SetDm(int i, double dm) override;
 
     virtual double GetDm(int i) const override
       { return fPMNS_Sterile->GetDm(i); }
@@ -48,7 +48,7 @@ namespace osc
 
     void SetState(std::vector<double> state);
 
-    //Getters
+    // Getters
     int GetNFlavors() const { return fPMNS_Sterile->GetNFlavors(); }
     std::vector<double> GetState() const;
     virtual TMD5* GetParamsHash() const override;

--- a/OscLib/OscCalcSterileEigen.cxx
+++ b/OscLib/OscCalcSterileEigen.cxx
@@ -130,59 +130,17 @@ namespace osc
   }
 
   //---------------------------------------------------------------------------
-  void OscCalcSterileEigen::SetDm(int j, double dm) 
+  void OscCalcSterileEigen::SetDm(int i, double dm) 
   {
-    if(j<2 || j>fNumNus){
-      cout << "Dm" << j << "1 not valid for " << fNumNus;
+    if (i < 2 || i > fNumNus) {
+      cout << "Dm" << i << "1 not valid for " << fNumNus;
       cout << " neutrinos. Doing nothing." << endl;
       return;
     }
 
-    fDm(j-1) = dm;
+    fDm(i-1) = dm;
 
     fBuiltHms = false;
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterileEigen::SetDmsq21(const double&)
-  {
-    std::cerr << "Must use SetDm!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterileEigen::SetDmsq32(const double&)
-  {
-    std::cerr << "Must use SetDm!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterileEigen::SetTh12(const double&)
-  {
-    std::cerr << "Must use SetAngle!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterileEigen::SetTh13(const double&)
-  {
-    std::cerr << "Must use SetAngle!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterileEigen::SetTh23(const double&)
-  {
-    std::cerr << "Must use SetAngle!" << std::endl;
-    assert(false);
-  }
-
-  //---------------------------------------------------------------------------
-  void OscCalcSterileEigen::SetdCP(const double&)
-  {
-    std::cerr << "Must use SetDelta!" << std::endl;
-    assert(false);
   }
 
   //---------------------------------------------------------------------------
@@ -433,72 +391,6 @@ namespace osc
     PropMatter(fL, E, fRho/2, anti);
     if (j == 3) return GetP(0) + GetP(1) + GetP(2);
     else return GetP(j);
-  }
-
-  //---------------------------------------------------------------------------
-  OscCalcSterileEigenTrivial::OscCalcSterileEigenTrivial()
-    : OscCalcSterileEigen()
-  {}
-
-  //---------------------------------------------------------------------------
-  OscCalcSterileEigenTrivial::OscCalcSterileEigenTrivial(
-    const OscCalcSterileEigen& calc)
-    : OscCalcSterileEigen(calc)
-  {}
-
-  //---------------------------------------------------------------------------
-  OscCalcSterileEigenTrivial::OscCalcSterileEigenTrivial(
-    const OscCalcSterileEigenTrivial& calc)
-    : OscCalcSterileEigenTrivial()
-  {
-    fL          = calc.fL;
-    fCachedNe   = calc.fCachedNe;
-    fCachedE    = calc.fCachedE;
-    fCachedAnti = calc.fCachedAnti;
-    fDm         = calc.fDm;
-    fTheta      = calc.fTheta;
-    fDelta      = calc.fDelta;
-    fNuState    = calc.fNuState;
-    fHms        = calc.fHms;
-    fHmsMat     = calc.fHmsMat;
-  }
-
-  //---------------------------------------------------------------------------
-  IOscCalcAdjustable* OscCalcSterileEigenTrivial::Copy() const
-  {
-    return new OscCalcSterileEigenTrivial(*this);
-  }
-
-  //---------------------------------------------------------------------------
-  double OscCalcSterileEigenTrivial::P(int, int, double)
-  {
-    return 1;
-  }
-
-  //---------------------------------------------------------------------------
-  const OscCalcSterileEigen* DowncastToSterileEigen(const IOscCalc* calc)
-  {
-    const OscCalcSterileEigenTrivial* calcTrivial
-      = dynamic_cast<const OscCalcSterileEigenTrivial*>(calc);
-    if (calcTrivial) return calcTrivial; 
-    const OscCalcSterileEigen* calcSterile
-      = dynamic_cast<const OscCalcSterileEigen*>(calc);
-    if(calcSterile) return calcSterile;
-    cout << "Input calculator was not of type OscCalcSterileEigen." << endl;
-    return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
-  }
-
-  //---------------------------------------------------------------------------
-  OscCalcSterileEigen* DowncastToSterileEigen(IOscCalc* calc)
-  {
-    OscCalcSterileEigenTrivial* calcTrivial
-      = dynamic_cast<OscCalcSterileEigenTrivial*>(calc);
-    if (calcTrivial) return calcTrivial;
-    OscCalcSterileEigen* calcSterile
-      = dynamic_cast<OscCalcSterileEigen*>(calc);
-    if(calcSterile) return calcSterile;
-    cout << "Input calculator was not of type OscCalcSterileEigen." << endl;
-    return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
   }
 
 } // namespace

--- a/OscLib/OscCalcSterileEigen.cxx
+++ b/OscLib/OscCalcSterileEigen.cxx
@@ -1,0 +1,436 @@
+#include "OscLib/OscCalcSterileEigen.h"
+#include "OscLib/OscCalcPMNSOptEigen.h"
+
+#include <iostream>
+#include <cassert>
+#include <stdlib.h>
+
+using std::complex;
+using std::cout;
+using std::endl;
+using std::list;
+
+namespace osc
+{
+
+  //---------------------------------------------------------------------------
+  OscCalcSterileEigen::OscCalcSterileEigen() : fNumNus(4)
+  {
+    this->SetStdPars();
+    this->ResetToFlavour(1);
+    fCachedNe = 0.0;
+    fCachedE =  1.0;
+    fCachedAnti = 1;
+  }
+
+  //---------------------------------------------------------------------------
+  OscCalcSterileEigen::OscCalcSterileEigen(const OscCalcSterileEigen& calc)
+  {
+    fL          = calc.fL;
+    fCachedNe   = calc.fCachedNe;
+    fCachedE    = calc.fCachedE;
+    fCachedAnti = calc.fCachedAnti;
+    fDm         = calc.fDm;
+    fTheta      = calc.fTheta;
+    fDelta      = calc.fDelta;
+    fNuState    = calc.fNuState;
+    fHms        = calc.fHms;
+    fHmsMat     = calc.fHmsMat;
+  }
+
+  //---------------------------------------------------------------------------
+  OscCalcSterileEigen::~OscCalcSterileEigen()
+  {}
+
+  //---------------------------------------------------------------------------
+  IOscCalcAdjustable* OscCalcSterileEigen::Copy() const
+  {
+    return new OscCalcSterileEigen(*this);
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::InitializeVectors()
+  {
+    fDm.setZero();
+    fTheta.setZero();
+    fDelta.setZero();
+    
+    fNuState.setZero();
+    fHms.setZero();
+    fHmsMat.setZero();
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetStdPars()
+  {
+
+    this->InitializeVectors();
+
+    if(fNumNus>2){
+      this->SetAngle(1,2,0.6);
+      this->SetAngle(1,3,0.16);
+      this->SetAngle(2,3,0.7);
+      this->SetDm(2,7.6e-5);
+      this->SetDm(3,2.4e-3);
+    }
+    else if(fNumNus==2){
+      this->SetAngle(1,2,0.7);
+      this->SetDm(2,2.4e-3);
+    }
+   
+  }
+
+  //--------------------------------------------------------------------------- 
+  void OscCalcSterileEigen::SetAngle(int i, int j, double th) 
+  {
+
+    if(i>j){
+      cout << "First argument should be smaller than second argument" << endl;
+      cout << "Setting reverse order (Theta" << j << i << "). " << endl;
+      int temp = i;
+      i = j;
+      j = temp;
+    }
+    if(i<1 || i>fNumNus-1 || j<2 || j>fNumNus){
+      cout << "Theta" << i << j << " not valid for " << fNumNus;
+      cout << " neutrinos. Doing nothing." << endl;
+      return;
+    }
+
+    fTheta(i-1,j-1) = th;
+
+    fBuiltHms = false;
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetDelta(int i, int j, double delta) 
+  {
+
+    if(i>j){
+      cout << "First argument should be smaller than second argument" << endl;
+      cout << "Setting reverse order (Delta" << j << i << "). " << endl;
+      int temp = i;
+      i = j;
+      j = temp;
+    }
+    if(i<1 || i>fNumNus-1 || j<2 || j>fNumNus){
+      cout << "Delta" << i << j << " not valid for " << fNumNus;
+      cout << " neutrinos. Doing nothing." << endl;
+      return;
+    }
+    if(i+1==j){
+      cout << "Rotation " << i << j << " is real. Doing nothing." << endl;
+      return;
+    }
+
+    fDelta(i-1,j-1) = delta;
+
+    fBuiltHms = false;
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetDm(int j, double dm) 
+  {
+    if(j<2 || j>fNumNus){
+      cout << "Dm" << j << "1 not valid for " << fNumNus;
+      cout << " neutrinos. Doing nothing." << endl;
+      return;
+    }
+
+    fDm(j-1) = dm;
+
+    fBuiltHms = false;
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetDmsq21(const double&)
+  {
+    std::cerr << "Must use SetDm!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetDmsq32(const double&)
+  {
+    std::cerr << "Must use SetDm!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetTh12(const double&)
+  {
+    std::cerr << "Must use SetAngle!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetTh13(const double&)
+  {
+    std::cerr << "Must use SetAngle!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetTh23(const double&)
+  {
+    std::cerr << "Must use SetAngle!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SetdCP(const double&)
+  {
+    std::cerr << "Must use SetDelta!" << std::endl;
+    assert(false);
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::RotateH(int i,int j){
+
+    // Do nothing if angle is zero
+    if(fTheta(i,j)==0) return;
+
+    double fSinBuffer(0), fCosBuffer(0);
+    _sincos(fTheta(i,j), fSinBuffer, fCosBuffer);
+    
+    double  fHmsBufferD;
+    complex fHmsBufferC;
+
+    // With Delta
+    if(i+1<j){
+      double fSinDelta(0), fCosDelta(0);
+      _sincos(fDelta(i,j),fSinDelta, fCosDelta);
+      complex fExpBuffer = complex(fCosDelta, -fSinDelta);
+
+      // General case
+      if(i>0){
+        // Top columns
+        for(int k=0; k<i; k++){
+          fHmsBufferC = fHms(k,i);
+
+          fHms(k,i) *= fCosBuffer;
+          fHms(k,i) += fHms(k,j) * fSinBuffer * conj(fExpBuffer);
+
+          fHms(k,j) *= fCosBuffer;
+          fHms(k,j) -= fHmsBufferC * fSinBuffer * fExpBuffer;
+        }
+
+        // Middle row and column
+        for(int k=i+1; k<j; k++){
+          fHmsBufferC = fHms(k,j);
+      
+          fHms(k,j) *= fCosBuffer;
+          fHms(k,j) -= conj(fHms(i,k)) * fSinBuffer * fExpBuffer;
+
+          fHms(i,k) *= fCosBuffer;
+          fHms(i,k) += fSinBuffer * fExpBuffer * conj(fHmsBufferC);
+        }
+
+        // Nodes ij
+        fHmsBufferC = fHms(i,i);
+        fHmsBufferD = real(fHms(j,j));
+
+        fHms(i,i) *= fCosBuffer * fCosBuffer;
+        fHms(i,i) += 2 * fSinBuffer * fCosBuffer * real(fHms(i,j) * conj(fExpBuffer));
+        fHms(i,i) += fSinBuffer * fHms(j,j) * fSinBuffer;
+
+        fHms(j,j) *= fCosBuffer * fCosBuffer;
+        fHms(j,j) += fSinBuffer * fHmsBufferC * fSinBuffer;
+        fHms(j,j) -= 2 * fSinBuffer * fCosBuffer * real(fHms(i,j) * conj(fExpBuffer));
+    
+        fHms(i,j) -= 2 * fSinBuffer * real(fHms(i,j) * conj(fExpBuffer)) * fSinBuffer * fExpBuffer;
+        fHms(i,j) += fSinBuffer * fCosBuffer * (fHmsBufferD - fHmsBufferC) * fExpBuffer;
+
+      }
+      // First rotation on j (No top columns)
+      else{
+        // Middle rows and columns
+        for(int k=i+1; k<j; k++){
+          fHms(k,j) = -conj(fHms(i,k)) * fSinBuffer * fExpBuffer;
+
+          fHms(i,k) *= fCosBuffer;
+        }
+
+        // Nodes ij
+        fHmsBufferD = real(fHms(i,i));
+
+        fHms(i,j) = fSinBuffer * fCosBuffer * (fHms(j,j) - fHmsBufferD) * fExpBuffer;
+
+        fHms(i,i) *= fCosBuffer * fCosBuffer;
+        fHms(i,i) += fSinBuffer * fHms(j,j) * fSinBuffer;
+
+        fHms(j,j) *= fCosBuffer * fCosBuffer;
+        fHms(j,j) += fSinBuffer * fHmsBufferD * fSinBuffer;
+      }
+    
+    }
+    // Without Delta (No middle rows or columns: j = i+1)
+    else{
+      // General case
+      if(i>0){
+        // Top columns
+        for(int k=0; k<i; k++){
+          fHmsBufferC = fHms(k,i);
+
+          fHms(k,i) *= fCosBuffer;
+          fHms(k,i) += fHms(k,j) * fSinBuffer;
+
+          fHms(k,j) *= fCosBuffer;
+          fHms(k,j) -= fHmsBufferC * fSinBuffer;
+        }
+
+        // Nodes ij
+        fHmsBufferC = fHms(i,i);
+        fHmsBufferD = real(fHms(j,j));
+
+        fHms(i,i) *= fCosBuffer * fCosBuffer;
+        fHms(i,i) += 2 * fSinBuffer * fCosBuffer * real(fHms(i,j));
+        fHms(i,i) += fSinBuffer * fHms(j,j) * fSinBuffer;
+
+        fHms(j,j) *= fCosBuffer * fCosBuffer;
+        fHms(j,j) += fSinBuffer * fHmsBufferC * fSinBuffer;
+        fHms(j,j) -= 2 * fSinBuffer * fCosBuffer * real(fHms(i,j));
+    
+        fHms(i,j) -= 2 * fSinBuffer * real(fHms(i,j)) * fSinBuffer;
+        fHms(i,j) += fSinBuffer * fCosBuffer * (fHmsBufferD - fHmsBufferC);
+
+      }
+      // First rotation (theta12)
+      else{
+
+        fHms(i,j) = fSinBuffer * fCosBuffer * fHms(j,j);
+
+        fHms(i,i) = fSinBuffer * fHms(j,j) * fSinBuffer;
+
+        fHms(j,j) *= fCosBuffer * fCosBuffer;
+    
+      }
+    }
+
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::BuildHms() 
+  {
+
+    // Check if anything changed
+    if(fBuiltHms) return;
+
+    //fHms.setZero(fNumNus, fNumNus);
+    
+    for(int j=0; j<fNumNus; j++){
+      // Set mass splitting
+      fHms(j,j) = fDm(j);
+      // Reset off-diagonal elements
+      for(int i=0; i<j; i++){
+        fHms(i,j) = 0;
+      }      
+      // Rotate j neutrinos
+      for(int i=0; i<j; i++){
+        this->RotateH(i,j);
+      }
+    }
+
+    // Tag as built
+    fBuiltHms = true;
+
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::SolveHam(double E, double Ne, int anti)
+  {
+
+    // Check if anything has changed before recalculating
+    if(Ne!=fCachedNe || E!=fCachedE || anti!=fCachedAnti || !fBuiltHms ){
+      fCachedNe = Ne;
+      fCachedE = E;
+      fCachedAnti = anti;
+      this->BuildHms();
+    }
+    else return;
+
+    double lv = 2 * kGeV2eV*E;          // 2E in eV 
+    double kr2GNe = kK2*M_SQRT2*kGf*Ne; // Matter potential in eV
+
+    fHmsMat = fHms;
+    
+    fHmsMat.triangularView<Eigen::Upper>() /= lv;
+    if (anti > 0) {
+      fHmsMat.adjointInPlace();
+      fHmsMat(0,0) += kr2GNe;
+      fHmsMat(3,3) += kr2GNe/2;
+    }
+    else {
+      fHmsMat.transposeInPlace();
+      fHmsMat(0,0) += -kr2GNe;
+      fHmsMat(3,3) += -kr2GNe/2;
+    }
+    
+    fEig.compute(fHmsMat);
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::PropMatter(double L, double E, double Ne, int anti) 
+  {
+    // Solve Hamiltonian
+    this->SolveHam(E, Ne, anti);
+
+    fNuState = fEig.eigenvectors()*(
+  				  fEig.eigenvalues().unaryExpr([L] (double x) { double sinx(0), cosx(0); _sincos(-kKm2eV*L*x,sinx,cosx); return complex(cosx, sinx);}
+  				  ).asDiagonal())*fEig.eigenvectors().adjoint()*fNuState;
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::PropMatter(const list<double>& L,
+                                       double E,
+                                       const list<double>& Ne,
+                                       int anti)
+  {
+    if (L.size()!=Ne.size()) abort();
+    list<double>::const_iterator Li  (L.begin());
+    list<double>::const_iterator Lend(L.end());
+    list<double>::const_iterator Ni  (Ne.begin());
+    for (; Li!=Lend; ++Li, ++Ni) {
+      this->PropMatter(*Li, E, *Ni, anti);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  double OscCalcSterileEigen::P(int flv) const
+  {
+    assert(flv>=0 && flv<fNumNus);
+    return norm(fNuState.coeff(flv));
+  }
+
+  //---------------------------------------------------------------------------
+  void OscCalcSterileEigen::ResetToFlavour(int flv) 
+  {
+    for (int i=0; i<fNumNus; ++i){
+      if (i==flv) fNuState(i) = one;
+      else        fNuState(i) = zero;
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  double OscCalcSterileEigen::P(int flavBefore, int flavAfter, double E)
+  {
+    const int anti = (flavBefore > 0) ? +1 : -1;
+    //anti must be +/- 1 but flavAfter can be zero
+    assert(flavAfter/anti >= 0);
+    
+    int i = -1, j = -1;
+    if(abs(flavBefore) == 12) i = 0;
+    if(abs(flavBefore) == 14) i = 1;
+    if(abs(flavBefore) == 16) i = 2;
+    if(abs(flavAfter) == 12) j = 0;
+    if(abs(flavAfter) == 14) j = 1;
+    if(abs(flavAfter) == 16) j = 2;
+    if(abs(flavAfter) == 0)  j = 3;
+    assert(i >= 0 && j >= 0);
+
+    ResetToFlavour(i);
+    PropMatter(fL, E, fRho/2, anti);
+    if (j == 3) return P(0) + P(1) + P(2);
+    else return P(j);
+  }
+} // namespace

--- a/OscLib/OscCalcSterileEigen.cxx
+++ b/OscLib/OscCalcSterileEigen.cxx
@@ -25,6 +25,7 @@ namespace osc
 
   //---------------------------------------------------------------------------
   OscCalcSterileEigen::OscCalcSterileEigen(const OscCalcSterileEigen& calc)
+    : fNumNus(4)
   {
     fL          = calc.fL;
     fCachedNe   = calc.fCachedNe;
@@ -66,7 +67,7 @@ namespace osc
 
     this->InitializeVectors();
 
-    if(fNumNus>2){
+    if(fNumNus>2) {
       this->SetAngle(1,2,0.6);
       this->SetAngle(1,3,0.16);
       this->SetAngle(2,3,0.7);
@@ -84,14 +85,14 @@ namespace osc
   void OscCalcSterileEigen::SetAngle(int i, int j, double th) 
   {
 
-    if(i>j){
+    if (i > j) {
       cout << "First argument should be smaller than second argument" << endl;
       cout << "Setting reverse order (Theta" << j << i << "). " << endl;
       int temp = i;
       i = j;
       j = temp;
     }
-    if(i<1 || i>fNumNus-1 || j<2 || j>fNumNus){
+    if (i < 1 || i > fNumNus - 1 || j < 2 || j > fNumNus) {
       cout << "Theta" << i << j << " not valid for " << fNumNus;
       cout << " neutrinos. Doing nothing." << endl;
       return;
@@ -396,16 +397,16 @@ namespace osc
   }
 
   //---------------------------------------------------------------------------
-  double OscCalcSterileEigen::P(int flv) const
+  double OscCalcSterileEigen::GetP(int flv) const
   {
-    assert(flv>=0 && flv<fNumNus);
+    assert(flv >= 0 && flv < fNumNus);
     return norm(fNuState.coeff(flv));
   }
 
   //---------------------------------------------------------------------------
   void OscCalcSterileEigen::ResetToFlavour(int flv) 
   {
-    for (int i=0; i<fNumNus; ++i){
+    for (int i = 0; i < fNumNus; ++i) {
       if (i==flv) fNuState(i) = one;
       else        fNuState(i) = zero;
     }
@@ -430,7 +431,74 @@ namespace osc
 
     ResetToFlavour(i);
     PropMatter(fL, E, fRho/2, anti);
-    if (j == 3) return P(0) + P(1) + P(2);
-    else return P(j);
+    if (j == 3) return GetP(0) + GetP(1) + GetP(2);
+    else return GetP(j);
   }
+
+  //---------------------------------------------------------------------------
+  OscCalcSterileEigenTrivial::OscCalcSterileEigenTrivial()
+    : OscCalcSterileEigen()
+  {}
+
+  //---------------------------------------------------------------------------
+  OscCalcSterileEigenTrivial::OscCalcSterileEigenTrivial(
+    const OscCalcSterileEigen& calc)
+    : OscCalcSterileEigen(calc)
+  {}
+
+  //---------------------------------------------------------------------------
+  OscCalcSterileEigenTrivial::OscCalcSterileEigenTrivial(
+    const OscCalcSterileEigenTrivial& calc)
+    : OscCalcSterileEigenTrivial()
+  {
+    fL          = calc.fL;
+    fCachedNe   = calc.fCachedNe;
+    fCachedE    = calc.fCachedE;
+    fCachedAnti = calc.fCachedAnti;
+    fDm         = calc.fDm;
+    fTheta      = calc.fTheta;
+    fDelta      = calc.fDelta;
+    fNuState    = calc.fNuState;
+    fHms        = calc.fHms;
+    fHmsMat     = calc.fHmsMat;
+  }
+
+  //---------------------------------------------------------------------------
+  IOscCalcAdjustable* OscCalcSterileEigenTrivial::Copy() const
+  {
+    return new OscCalcSterileEigenTrivial(*this);
+  }
+
+  //---------------------------------------------------------------------------
+  double OscCalcSterileEigenTrivial::P(int, int, double)
+  {
+    return 1;
+  }
+
+  //---------------------------------------------------------------------------
+  const OscCalcSterileEigen* DowncastToSterileEigen(const IOscCalc* calc)
+  {
+    const OscCalcSterileEigenTrivial* calcTrivial
+      = dynamic_cast<const OscCalcSterileEigenTrivial*>(calc);
+    if (calcTrivial) return calcTrivial; 
+    const OscCalcSterileEigen* calcSterile
+      = dynamic_cast<const OscCalcSterileEigen*>(calc);
+    if(calcSterile) return calcSterile;
+    cout << "Input calculator was not of type OscCalcSterileEigen." << endl;
+    return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
+  }
+
+  //---------------------------------------------------------------------------
+  OscCalcSterileEigen* DowncastToSterileEigen(IOscCalc* calc)
+  {
+    OscCalcSterileEigenTrivial* calcTrivial
+      = dynamic_cast<OscCalcSterileEigenTrivial*>(calc);
+    if (calcTrivial) return calcTrivial;
+    OscCalcSterileEigen* calcSterile
+      = dynamic_cast<OscCalcSterileEigen*>(calc);
+    if(calcSterile) return calcSterile;
+    cout << "Input calculator was not of type OscCalcSterileEigen." << endl;
+    return nullptr; // If the cast failed, calc_sterile should be nullptr anyway
+  }
+
 } // namespace

--- a/OscLib/OscCalcSterileEigen.h
+++ b/OscLib/OscCalcSterileEigen.h
@@ -10,7 +10,7 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-#include "OscLib/IOscCalc.h"
+#include "OscLib/IOscCalcSterile.h"
 #include <Eigen/Dense>
 #include <list>
 
@@ -19,7 +19,7 @@ namespace osc
   /// \brief Eigen-based 3+1 sterile oscillation calculator
   ///
   /// Adapt the \ref PMNS_Sterile calculator to Eigen, hardcoded to 3+1
-  class OscCalcSterileEigen: public IOscCalcAdjustable
+  class OscCalcSterileEigen: public IOscCalcSterile
   {  
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -30,29 +30,21 @@ namespace osc
 
     virtual IOscCalcAdjustable* Copy() const override;
 
-    virtual double P(int flavBefore, int flavAfter, double E) override;
+    virtual void SetAngle(int i, int j, double th) override;
+    virtual void SetDelta(int i, int j, double delta) override;
+    virtual void SetDm(int i, double dm) override;
 
-    virtual void SetL(double l)     override { fL = l; }
-    virtual void SetRho(double rho) override { fRho = rho; }
-    
-    /// Set the parameters of the PMNS matrix
-    /// @param th    - The angle theta_ij in radians
-    virtual void SetAngle(int i, int j, double th);
-    virtual void SetDelta(int i, int j, double delta);
-    
-    /// Set the mass-splittings
-    /// @param dmi1 - mi^2-m1^2 in eV^2
-    virtual void SetDm(int i, double dm);
+    virtual double GetDm(int i) const override
+      { return fDm(i-1); }
+    virtual double GetAngle(int i, int j) const override
+      { return fTheta(i-1, j-1); }
+    virtual double GetDelta(int i, int j) const override
+      { return fDelta(i-1, j-1); }
+
+    virtual double P(int flavBefore, int flavAfter, double E) override;
     
     /// Set standard 3-flavor parameters
     virtual void SetStdPars();
-
-    //Getters
-    double GetL()                 const override { return fL; }
-    double GetRho()               const override { return fRho; }
-    double GetDm(int i)           const { return fDm(i-1); }
-    double GetAngle(int i, int j) const { return fTheta(i-1, j-1); }
-    double GetDelta(int i, int j) const { return fDelta(i-1, j-1); }
 
   protected:
     
@@ -93,13 +85,6 @@ namespace osc
     /// to pure flavour flv. Preserves values of mixing and mass-splittings
     /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
     virtual void ResetToFlavour(int flv=1);
-
-    virtual void SetDmsq21(const double& dmsq21) override;
-    virtual void SetDmsq32(const double& dmsq32) override;
-    virtual void SetTh12  (const double& th12  ) override;
-    virtual void SetTh13  (const double& th13  ) override;
-    virtual void SetTh23  (const double& th23  ) override;
-    virtual void SetdCP   (const double& dCP   ) override;
     
     int fNumNus;
 
@@ -107,7 +92,6 @@ namespace osc
     double  fCachedE;       ///< Cached neutrino energy
     int     fCachedAnti;    ///< Cached nu/nubar selector
     bool    fBuiltHms;      ///< Tag to avoid rebuilding Hms
-    double  fRho;           ///< Electron density
 
     Eigen::Vector4d  fDm;      ///< m^2_i - m^2_1 in vacuum
     Eigen::Matrix4d  fTheta;   ///< theta[i][j] mixing angle
@@ -118,25 +102,6 @@ namespace osc
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix4cd> fEig;  ///< eigen solver
 
   };
-
-  /// \brief Version of OscCalcSterile that always returns probability of 1
-  class OscCalcSterileEigenTrivial: public OscCalcSterileEigen
-  {
-  public:
-    using IOscCalc::P;
-    OscCalcSterileEigenTrivial();
-    OscCalcSterileEigenTrivial(const OscCalcSterileEigen& calc);
-    OscCalcSterileEigenTrivial(const OscCalcSterileEigenTrivial& calc);
-    virtual ~OscCalcSterileEigenTrivial() {};
-
-    virtual IOscCalcAdjustable* Copy() const override;
-    
-    // Always return 1
-    virtual double P(int flavBefore, int flavAfter, double E) override;
-  };
-
-  const OscCalcSterileEigen* DowncastToSterileEigen(const IOscCalc* calc);
-  OscCalcSterileEigen* DowncastToSterileEigen(IOscCalc* calc);
 
 } // namespace
 

--- a/OscLib/OscCalcSterileEigen.h
+++ b/OscLib/OscCalcSterileEigen.h
@@ -10,14 +10,8 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-// #include <complex>
-//#include <vector>
-
 #include "OscLib/IOscCalc.h"
-
 #include <Eigen/Dense>
-// #include "<Eigen/Eigenvalues>"
-
 #include <list>
 
 namespace osc
@@ -56,29 +50,9 @@ namespace osc
     //Getters
     double GetL()                 const override { return fL; }
     double GetRho()               const override { return fRho; }
-    double GetDm(int i)           const { return fDm(i); }
-    double GetAngle(int i, int j) const { return fTheta(i, j); }
-    double GetDelta(int i, int j) const { return fDelta(i, j); }
-    
-    /// Propagate a neutrino through a slab of matter
-    /// @param L - length of slab (km)
-    /// @param E - neutrino energy in GeV
-    /// @param Ne - electron number density of matter in mole/cm^3
-    /// @param anti - +1 = neutrino case, -1 = anti-neutrino case
-    virtual void PropMatter(double L, double E, double Ne, int anti=1);
-    virtual void PropMatter(const std::list<double>& L,
-  			  double                   E,
-  			  const std::list<double>& Ne,
-  			  int anti);
-    
-    /// Return the probability of final state in flavour flv
-    /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
-    virtual double P(int flv) const;
-    
-    /// Erase memory of neutrino propagate and reset neutrino
-    /// to pure flavour flv. Preserves values of mixing and mass-splittings
-    /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
-    virtual void ResetToFlavour(int flv=1);
+    double GetDm(int i)           const { return fDm(i-1); }
+    double GetAngle(int i, int j) const { return fTheta(i-1, j-1); }
+    double GetDelta(int i, int j) const { return fDelta(i-1, j-1); }
 
   protected:
     
@@ -99,6 +73,26 @@ namespace osc
     /// @param Ne - electron number density of matter in mole/cm^3
     /// @param anti - +1 = neutrino case, -1 = anti-neutrino case
     virtual void SolveHam(double E, double Ne, int anti);
+
+    /// Propagate a neutrino through a slab of matter
+    /// @param L - length of slab (km)
+    /// @param E - neutrino energy in GeV
+    /// @param Ne - electron number density of matter in mole/cm^3
+    /// @param anti - +1 = neutrino case, -1 = anti-neutrino case
+    virtual void PropMatter(double L, double E, double Ne, int anti=1);
+    virtual void PropMatter(const std::list<double>& L,
+              double                   E,
+              const std::list<double>& Ne,
+              int anti);
+    
+    /// Return the probability of final state in flavour flv
+    /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
+    virtual double GetP(int flv) const;
+    
+    /// Erase memory of neutrino propagate and reset neutrino
+    /// to pure flavour flv. Preserves values of mixing and mass-splittings
+    /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
+    virtual void ResetToFlavour(int flv=1);
 
     virtual void SetDmsq21(const double& dmsq21) override;
     virtual void SetDmsq32(const double& dmsq32) override;
@@ -124,6 +118,25 @@ namespace osc
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix4cd> fEig;  ///< eigen solver
 
   };
+
+  /// \brief Version of OscCalcSterile that always returns probability of 1
+  class OscCalcSterileEigenTrivial: public OscCalcSterileEigen
+  {
+  public:
+    using IOscCalc::P;
+    OscCalcSterileEigenTrivial();
+    OscCalcSterileEigenTrivial(const OscCalcSterileEigen& calc);
+    OscCalcSterileEigenTrivial(const OscCalcSterileEigenTrivial& calc);
+    virtual ~OscCalcSterileEigenTrivial() {};
+
+    virtual IOscCalcAdjustable* Copy() const override;
+    
+    // Always return 1
+    virtual double P(int flavBefore, int flavAfter, double E) override;
+  };
+
+  const OscCalcSterileEigen* DowncastToSterileEigen(const IOscCalc* calc);
+  OscCalcSterileEigen* DowncastToSterileEigen(IOscCalc* calc);
 
 } // namespace
 

--- a/OscLib/OscCalcSterileEigen.h
+++ b/OscLib/OscCalcSterileEigen.h
@@ -1,0 +1,130 @@
+#ifndef OSC_OSCCALCSTERILEEIGEN_H
+#define OSC_OSCCALCSTERILEEIGEN_H
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// \file OscCalcSterile.h                                               //
+//                                                                      //
+// Adapt the PMNS_Sterile calculator to 3+1 oscillations with Eigen     //
+// <jhewes15@fnal.gov>                                                  //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+// #include <complex>
+//#include <vector>
+
+#include "OscLib/IOscCalc.h"
+
+#include <Eigen/Dense>
+// #include "<Eigen/Eigenvalues>"
+
+#include <list>
+
+namespace osc
+{
+  /// \brief Eigen-based 3+1 sterile oscillation calculator
+  ///
+  /// Adapt the \ref PMNS_Sterile calculator to Eigen, hardcoded to 3+1
+  class OscCalcSterileEigen: public IOscCalcAdjustable
+  {  
+  public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    using IOscCalcAdjustable::P;
+    OscCalcSterileEigen();
+    OscCalcSterileEigen(const OscCalcSterileEigen& calc);
+    virtual ~OscCalcSterileEigen();
+
+    virtual IOscCalcAdjustable* Copy() const override;
+
+    virtual double P(int flavBefore, int flavAfter, double E) override;
+
+    virtual void SetL(double l)     override { fL = l; }
+    virtual void SetRho(double rho) override { fRho = rho; }
+    
+    /// Set the parameters of the PMNS matrix
+    /// @param th    - The angle theta_ij in radians
+    virtual void SetAngle(int i, int j, double th);
+    virtual void SetDelta(int i, int j, double delta);
+    
+    /// Set the mass-splittings
+    /// @param dmi1 - mi^2-m1^2 in eV^2
+    virtual void SetDm(int i, double dm);
+    
+    /// Set standard 3-flavor parameters
+    virtual void SetStdPars();
+
+    //Getters
+    double GetL()                 const override { return fL; }
+    double GetRho()               const override { return fRho; }
+    double GetDm(int i)           const { return fDm(i); }
+    double GetAngle(int i, int j) const { return fTheta(i, j); }
+    double GetDelta(int i, int j) const { return fDelta(i, j); }
+    
+    /// Propagate a neutrino through a slab of matter
+    /// @param L - length of slab (km)
+    /// @param E - neutrino energy in GeV
+    /// @param Ne - electron number density of matter in mole/cm^3
+    /// @param anti - +1 = neutrino case, -1 = anti-neutrino case
+    virtual void PropMatter(double L, double E, double Ne, int anti=1);
+    virtual void PropMatter(const std::list<double>& L,
+  			  double                   E,
+  			  const std::list<double>& Ne,
+  			  int anti);
+    
+    /// Return the probability of final state in flavour flv
+    /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
+    virtual double P(int flv) const;
+    
+    /// Erase memory of neutrino propagate and reset neutrino
+    /// to pure flavour flv. Preserves values of mixing and mass-splittings
+    /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
+    virtual void ResetToFlavour(int flv=1);
+
+  protected:
+    
+    // A shorthand...
+    typedef std::complex<double> complex;
+    
+    virtual void InitializeVectors();
+    
+    /// Rotate the Hamiltonian by theta_ij and delta_ij
+    virtual void RotateH(int i,int j);
+    
+    /// Build Hms = H*2E, where H is the Hamiltonian in vacuum on flavour basis   
+    /// and E is the neutrino energy. This is effectively the matrix of masses squared.
+    virtual void BuildHms();
+    
+    /// Solve the full Hamiltonian for eigenvectors and eigenvalues
+    /// @param E - neutrino energy in GeV
+    /// @param Ne - electron number density of matter in mole/cm^3
+    /// @param anti - +1 = neutrino case, -1 = anti-neutrino case
+    virtual void SolveHam(double E, double Ne, int anti);
+
+    virtual void SetDmsq21(const double& dmsq21) override;
+    virtual void SetDmsq32(const double& dmsq32) override;
+    virtual void SetTh12  (const double& th12  ) override;
+    virtual void SetTh13  (const double& th13  ) override;
+    virtual void SetTh23  (const double& th23  ) override;
+    virtual void SetdCP   (const double& dCP   ) override;
+    
+    int fNumNus;
+
+    double  fCachedNe;      ///< Cached electron density
+    double  fCachedE;       ///< Cached neutrino energy
+    int     fCachedAnti;    ///< Cached nu/nubar selector
+    bool    fBuiltHms;      ///< Tag to avoid rebuilding Hms
+    double  fRho;           ///< Electron density
+
+    Eigen::Vector4d  fDm;      ///< m^2_i - m^2_1 in vacuum
+    Eigen::Matrix4d  fTheta;   ///< theta[i][j] mixing angle
+    Eigen::Matrix4d  fDelta;   ///< delta[i][j] CP violating phase
+    Eigen::Vector4cd  fNuState; ///< The neutrino current state
+    Eigen::Matrix4cd  fHms;     ///< matrix H*2E in eV^2
+    Eigen::Matrix4cd  fHmsMat;  ///< matrix H*2E in eV^2, with matter
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix4cd> fEig;  ///< eigen solver
+
+  };
+
+} // namespace
+
+#endif


### PR DESCRIPTION
Add in a new Eigen implementation for the standard sterile osc calculator, which uses 4D vectors and matrices to calculate 3+1 sterile neutrino oscillations. The translation to Eigen was performed by Adam Aurisano, and the class was implemented in OscLib by me (J Hewes).

I have successfully built OscLib, used my local OscLib package to override the default OscLib in UPS, and confirmed the code works successfully in CAFAna. I've confirmed probabilities calculated by OscCalcSterileEigen are numerically identical to those produced by OscCalcSterile, and find the Eigen calculator provides a 40% speed improvement. I've already adapted NuXAna to use this new calculator, and tested analysis macros work as intended, but those changes cannot be committed until a new release of OscLib is made available.