### PR TITLE
bug fix in OscCalcSterileEigen

### DIFF
--- a/OscLib/OscCalcSterileEigen.cxx
+++ b/OscLib/OscCalcSterileEigen.cxx
@@ -27,6 +27,7 @@ namespace osc
   OscCalcSterileEigen::OscCalcSterileEigen(const OscCalcSterileEigen& calc)
     : fNumNus(4)
   {
+    fRho        = calc.fRho;
     fL          = calc.fL;
     fCachedNe   = calc.fCachedNe;
     fCachedE    = calc.fCachedE;


### PR DESCRIPTION
finally tracked down some weird behaviour in the Eigen sterile calc: the copy constructor doesn't copy the matter density, so any copied calcs are initialised with a random matter density :/