### PR TITLE
Feature/gsdavies sbn root upgrade

### DIFF
--- a/jenkins/dependencies.sh
+++ b/jenkins/dependencies.sh
@@ -10,21 +10,21 @@ fi
 
 QUAL=$1
 
-if [[ $QUAL == *:n308* ]]; then NQUAL=n308; QUAL=${QUAL/:n308/}; fi
-if [[ $QUAL == *:n311* ]]; then NQUAL=n311; QUAL=${QUAL/:n311/}; fi
+if [[ $QUAL == *:n313* ]]; then NQUAL=n313; QUAL=${QUAL/:n313/}; fi
+if [[ $QUAL == *:n315* ]]; then NQUAL=n315; QUAL=${QUAL/:n315/}; fi
 
 WANTSTAN=yes
 if [[ $QUAL == *:stanfree ]]; then WANTSTAN=no; QUAL=${QUAL/:stanfree/}; else QUAL=${QUAL/:stan/}; fi
 
-if [[ $NQUAL == n308 ]]
+if [[ $NQUAL == n313 ]]
 then
-    # These are the current (Apr 2021) nova versions (nutools v3_08_00)
-    echo root v6_18_04d -q$QUAL
-    echo boost v1_70_0 -q$QUAL
-else
-    # These are the current (October 2021) sbn versions (nutools v3_11_05)
+    # These are the current (May 2023) nova versions (nutools v3_13_04b)
     echo root v6_22_08d -q${QUAL}:p392
     echo boost v1_75_0 -q$QUAL
+else
+    # These are the current (July 2023) sbn versions (nutools v3_15_03)
+    echo root v6_26_06b -q${QUAL}:p3913
+    echo boost v1_80_0 -q$QUAL
 fi
 
 echo eigen v3_3_9a

--- a/jenkins/jenkins_build.sh
+++ b/jenkins/jenkins_build.sh
@@ -3,9 +3,9 @@
 set +ex
 env
 
-if [[ $QUALIFIER != *:n308* && $QUALIFIER != *:n311* ]]
+if [[ $QUALIFIER != *:n313* && $QUALIFIER != *:n315* ]]
 then
-    echo Unspecified nutools version in qualifier $QUALIFIER -- must be n308 or n311
+    echo Unspecified nutools version in qualifier $QUALIFIER -- must be n313 or n315
     exit 1
 fi
 


### PR DESCRIPTION
tested build locally. prepping for tag, jenkins build, and deployment.
fulfills SBN request for art 3.12 upgrade, which means `root v6_26_06b` and `boost v1_80_0` -- these are part of `nutools v3_15_03` . SBN folks @cafana/sbn please check the SBN versions.
I'm leaving `eigen` at `v3_3_9a` for this tag but will then upgrade eigen everywhere to fulfill a long-time request.
This one is trickier because of the initial build issues I've observed but in discussion with Lynn Garren (CSAID) with regard to observations.