### PR TITLE
update to eigen 3.4.0

### DIFF
--- a/jenkins/dependencies.sh
+++ b/jenkins/dependencies.sh
@@ -31,5 +31,5 @@ echo eigen v3_4_0
 
 if [ $WANTSTAN == yes ]
 then
-    echo stan_math v4_2_1 -q$QUAL
+    echo stan_math v4_5_0a -q$QUAL
 fi

--- a/jenkins/dependencies.sh
+++ b/jenkins/dependencies.sh
@@ -27,9 +27,9 @@ else
     echo boost v1_80_0 -q$QUAL
 fi
 
-echo eigen v3_3_9a
+echo eigen v3_4_0
 
 if [ $WANTSTAN == yes ]
 then
-    echo stan_math v4_0_1 -q$QUAL
+    echo stan_math v4_2_1 -q$QUAL
 fi


### PR DESCRIPTION
we finally figured out the eigen dependency chain issue for NOvA with scisoft. we move forward to eigen 3.4.0, along with a new dependency-free stan_math 4.5.0. this change brings the NOvA ecosystem in line with the LArSoft stack in terms of our stan dependency, so this version bump should apply for all stakeholder experiments.