### PR TITLE
need sundials explicitly.

### DIFF
--- a/jenkins/dependencies.sh
+++ b/jenkins/dependencies.sh
@@ -31,5 +31,6 @@ echo eigen v3_4_0
 
 if [ $WANTSTAN == yes ]
 then
-    echo stan_math v4_5_0a -q$QUAL
+    echo stan_math v4_5_0a
+    echo sundials v6_5_0
 fi


### PR DESCRIPTION
No qualifiers, no dependencies for `stan_math`, `sundials`, although needed `sundials` for `OscLib` to build with the stan qualifier -- otherwise fails to find headers. Might be the makefile needs a tweak. At any rate, this gets us building. This was not obvious earlier. 