### PR TITLE
add cetmodules cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required (VERSION 3.20 FATAL_ERROR)
+
+find_package(cetmodules REQUIRED)
+project(osclib VERSION 0.23)
+
+include(CetCMakeEnv)
+cet_cmake_env()
+
+cet_set_compiler_flags(DIAGS CAUTIOUS
+  WERROR 
+  NO_UNDEFINED
+  EXTRA_FLAGS -pedantic -Wno-unused-local-typedefs
+)
+
+cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
+
+option(STAN "Build with Stan dependency")
+
+find_package(ROOT REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED)
+find_package(GSL REQUIRED)
+
+if(STAN)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOSCLIB_STAN -D_REENTRANT")
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  find_package(stan_math REQUIRED)
+  find_package(TBB REQUIRED)
+endif()
+
+add_subdirectory(OscLib)
+
+cet_cmake_config()

--- a/OscLib/CMakeLists.txt
+++ b/OscLib/CMakeLists.txt
@@ -1,0 +1,34 @@
+cet_make_library(LIBRARY_NAME OscLib
+  SOURCE
+  EarthModel.cxx
+  IOscCalc.cxx
+  IOscCalcSterile.cxx
+  OscCalc.cxx
+  OscCalcAnalytic.cxx
+  OscCalcCPT.cxx
+  OscCalcDMP.cxx
+  OscCalcDumb.cxx
+  OscCalcGeneral.cxx
+  OscCalcPMNS_CPT.cxx
+  OscCalcPMNS_NSI.cxx
+  OscCalcPMNS.cxx
+  OscCalcPMNSOpt.cxx
+  OscCalcPMNSOptEigen.cxx
+  OscCalcSterile.cxx
+  OscCalcSterileBeam.cxx
+  OscCalcSterileEigen.cxx
+  PMNS_DMP.cxx
+  PMNS_NSI.cxx
+  PMNS_Sterile.cxx
+  PMNS.cxx
+  PMNSOpt.cxx
+  LIBRARIES
+  GSL::gsl
+  ROOT::Core
+  ROOT::Hist
+  stan_math::stan_math
+  TBB::tbb
+)
+
+install_headers()
+install_source()

--- a/OscLib/CMakeLists.txt
+++ b/OscLib/CMakeLists.txt
@@ -1,3 +1,8 @@
+# optional stan dependency
+if (STAN)
+  set (STAN_TARGETS stan_math::stan_math TBB::tbb)
+endif (STAN)
+
 cet_make_library(LIBRARY_NAME OscLib
   SOURCE
   EarthModel.cxx
@@ -26,8 +31,7 @@ cet_make_library(LIBRARY_NAME OscLib
   GSL::gsl
   ROOT::Core
   ROOT::Hist
-  stan_math::stan_math
-  TBB::tbb
+  ${STAN_TARGETS}
 )
 
 install_headers()

--- a/cmake/Findstan_math.cmake
+++ b/cmake/Findstan_math.cmake
@@ -1,0 +1,53 @@
+#[================================================================[.rst:
+Findstan_math
+----------
+  find stan_math
+
+#]================================================================]
+
+#MESSAGE("stan_math_INC is $ENV{STAN_MATH_INC}")
+if (stan_math_FOUND)
+  set(_cet_stan_math_config_mode CONFIG_MODE)
+else()
+  unset(_cet_stan_math_config_mode)
+  find_file(_cet_stan_math_h NAMES stan/math.hpp HINTS ENV STAN_MATH_INC)
+  #MESSAGE("${_cet_stan_math_h}")
+  if (_cet_stan_math_h)
+    get_filename_component(_cet_stan_math_include_dir "${_cet_stan_math_h}" PATH)
+    #MESSAGE("${_cet_stan_math_include_dir}")
+    if (_cet_stan_math_include_dir STREQUAL "/")
+      unset(_cet_stan_math_include_dir)
+    endif()
+  endif()
+  if (EXISTS "${_cet_stan_math_include_dir}")
+    set(stan_math_FOUND TRUE)
+    #MESSAGE("FOUND - stan_math ${stan_math_FOUND}")
+    get_filename_component(_cet_stan_math_dir "${_cet_stan_math_include_dir}" PATH)
+    #MESSAGE("${_cet_stan_math_dir}")
+    if (_cet_stan_math_dir STREQUAL "/")
+      unset(_cet_stan_math_dir)
+    endif()
+    set(stan_math_INCLUDE_DIRS "$ENV{STAN_MATH_INC}")
+    #MESSAGE(VERBOSE "DIR set to ${stan_math_INCLUDE_DIRS}")
+  endif()
+endif()
+
+if (stan_math_FOUND
+    AND NOT TARGET stan_math::stan_math)
+  add_library(stan_math::stan_math INTERFACE IMPORTED)
+  set_target_properties(stan_math::stan_math PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${stan_math_INCLUDE_DIRS}"
+    INTERFACE_COMPILE_DEFINITIONS "${STAN_MATH_DEFINITIONS}"
+  )
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(stan_math ${_cet_stan_math_config_mode}
+  REQUIRED_VARS stan_math_FOUND
+  stan_math_INCLUDE_DIRS)
+
+unset(_cet_stan_math_FIND_REQUIRED)
+unset(_cet_stan_math_config_mode)
+unset(_cet_stan_math_dir)
+unset(_cet_stan_math_include_dir)
+unset(_cet_stan_math_h CACHE)


### PR DESCRIPTION
this PR adds a cmake build for compiling osclib with spack. i've created a corresponding Spack recipe, which i'll submit via PR to the `fnal_art` spack repo once this PR is merged and a new version has been cut. as with the existing makefile build, the dependency on stan is optional. i've copied novasoft's `Findstan_math.cmake` file into this repo, so we can build against stan – in the longer term, i'd like to build a more robust spack recipe for `stan_math` so this is no longer necessary, but this should work fine in the short term.