### PR TITLE
move to eigen v23_0_01 with stan_math patch

### DIFF
--- a/jenkins/dependencies.sh
+++ b/jenkins/dependencies.sh
@@ -33,11 +33,11 @@ else
     # nulite v3_16_6
     echo root v6_28_12 -q${QUAL}:p3915
     echo boost v1_82_0 -q$QUAL
-    echo eigen v3_4_0
+    echo eigen v23_08_01_66e8f
 fi
 
 if [ $WANTSTAN == yes ]
 then
-    echo stan_math v4_5_0a
-    echo sundials v6_5_0
+    echo stan_math v4_9_0a
+    echo sundials v7_1_1
 fi


### PR DESCRIPTION
- regarding [redmine issue 28782](https://cdcvs.fnal.gov/redmine/issues/28782), patch of stan_math to accompany updated eigen v23_08_01_66e8f, so OscLib works with the nulite v3_16_06 release.

I'm not special casing if we want to build earlier releases. This build system is becoming obsolete so it's not worth the extra effort.