### PR TITLE
Consolidate fundamental constants into one header

### DIFF
--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -7,26 +7,26 @@
 // \file Constants.h
 // \brief Keep important physical constants and unit conversions in one place.
 //        All values use the natural units system such that hbar = c = 1.
-//        All values are taken from PDG, Physical Constants Table 1.1, 2014.
+//        All values are taken from PDG, Physical Constants 1.1, 2024.
 // \author <cullenms@fnal.gov>
 
 namespace osc {
 namespace constants {
 
 /// G_F, the Fermi Constant in GeV^-2.
-const double kFermiConstant = 1.1663787e-5;
+const double kFermiConstant = 1.1663788e-5;
 
 /// N_A, Avogadro's number in mol^-1 (or if you prefer, electrons/mol when thinking about the matter effect).
-const double kAvogadroConstant = 6.02214129e23;
+const double kAvogadroConstant = 6.02214076e23;
 
 /// c, the speed of light (unitless). Multiply by c in natural units to convert s to m.
 const double kSpeedOfLight = 299792458;
 
 /// hbar, reduced Planck's constant (unitless). Multiply by hbar in natural units to convert invese seconds to joules.
-const double kReducedPlanckConstant = 1.054571726e-34;
+const double kReducedPlanckConstant = 1.054571817e-34;
 
 /// e, the elementary charge (J/eV).
-const double kElementaryCharge = 1.602176565e-19;
+const double kElementaryCharge = 1.602176364e-19;
 
 /// Unit conversion: m^-1 to eV.
 const double kInversemToeV =

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -31,13 +31,16 @@ const double kSpeedOfLight = 299792458;
 /// hbar, reduced Planck's constant (GeV*s = unitless). Multiply by hbar in natural units to convert s^-1 to GeV.
 const double kReducedPlanckConstant = 6.582119569e-25;
 
+/// Number of electrons per nucleon in a typical atom. Used for computing the matter effect.
+const double kZPerA = 0.5;
+
 /// Unit conversion: m^-1 to eV.
 const double kInversemToeV =
     kSpeedOfLight          // 1 m^-1 = SpeedOfLight s^-1.
   * kReducedPlanckConstant // 1 s^-1 = ReducedPlanckConstant GeV.
   * kGeVToeV;              // Finally convert GeV to eV.
 
-/// Given a matter density, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
+/// Given a matter density of electrons, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
 const double kMatterDensityToEffect =
     sqrt(2) * kFermiConstant * pow(kGeVToeV,-2)
   * kAvogadroConstant                          // 1 mol = 1 AvogadroConstant.

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -25,20 +25,17 @@ const double kFermiConstant = 1.1663788e-5;
 /// N_A, Avogadro's number in mol^-1 (or if you prefer, electrons/mol when thinking about the matter effect).
 const double kAvogadroConstant = 6.02214076e23;
 
-/// c, the speed of light (unitless). Multiply by c in natural units to convert s to m.
+/// c, the speed of light (m/s = unitless). Multiply by c in natural units to convert s to m.
 const double kSpeedOfLight = 299792458;
 
-/// hbar, reduced Planck's constant (unitless). Multiply by hbar in natural units to convert invese seconds to joules.
-const double kReducedPlanckConstant = 1.054571817e-34;
-
-/// e, the elementary charge (J/eV).
-const double kElementaryCharge = 1.602176364e-19;
+/// hbar, reduced Planck's constant (GeV*s = unitless). Multiply by hbar in natural units to convert 
+const double kReducedPlanckConstant = 6.582119569e-25;
 
 /// Unit conversion: m^-1 to eV.
 const double kInversemToeV =
     kSpeedOfLight          // 1 m^-1 = SpeedOfLight s^-1.
   * kReducedPlanckConstant // 1 s^-1 = ReducedPlanckConstant J.
-  / kElementaryCharge;     // ElementaryCharge J^-1 = eV.
+  / kGeVToeV;              // Finally convert GeV to eV.
 
 /// Given a matter density, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
 const double kMatterDensityToEffect =

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -36,7 +36,7 @@ const double kInversemToeV =
 
 /// Given a matter density, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
 const double kMatterDensityToEffect =
-    2 * sqrt(2) * kFermiConstant * 1e-18 // The 1e-18 converts the Fermi constant from GeV^-2 to eV^-2.
+    sqrt(2) * kFermiConstant * 1e-18 // The 1e-18 converts the Fermi constant from GeV^-2 to eV^-2.
   * kAvogadroConstant                    // 1 mol = 1 AvogadroConstant.
   * pow(kInversemToeV*100,3);
 

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -4,11 +4,11 @@
 
 #include <cmath>
 
-// \file Constants.h
-// \brief Keep important physical constants and unit conversions in one place.
-//        All values use the natural units system such that hbar = c = 1.
-//        All values are taken from PDG, Physical Constants 1.1, 2024.
-// \author <cullenms@fnal.gov>
+/// \file Constants.h
+/// \brief Keep important physical constants and unit conversions in one place.
+///        All values use the natural units system such that hbar = c = 1.
+///        All values are taken from PDG, Physical Constants 1.1, 2024.
+/// \author <cullenms@fnal.gov>
 
 namespace osc {
 namespace constants {

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -28,14 +28,14 @@ const double kAvogadroConstant = 6.02214076e23;
 /// c, the speed of light (m/s = unitless). Multiply by c in natural units to convert s to m.
 const double kSpeedOfLight = 299792458;
 
-/// hbar, reduced Planck's constant (GeV*s = unitless). Multiply by hbar in natural units to convert 
+/// hbar, reduced Planck's constant (GeV*s = unitless). Multiply by hbar in natural units to convert s^-1 to GeV.
 const double kReducedPlanckConstant = 6.582119569e-25;
 
 /// Unit conversion: m^-1 to eV.
 const double kInversemToeV =
     kSpeedOfLight          // 1 m^-1 = SpeedOfLight s^-1.
-  * kReducedPlanckConstant // 1 s^-1 = ReducedPlanckConstant J.
-  / kGeVToeV;              // Finally convert GeV to eV.
+  * kReducedPlanckConstant // 1 s^-1 = ReducedPlanckConstant GeV.
+  * kGeVToeV;              // Finally convert GeV to eV.
 
 /// Given a matter density, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
 const double kMatterDensityToEffect =

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -2,13 +2,46 @@
 #ifndef OSCLIB_CONSTANTS
 #define OSCLIB_CONSTANTS
 
+#include <cmath>
+
 // \file Constants.h
 // \brief Keep important physical constants and unit conversions in one place.
 //        All values use the natural units system such that hbar = c = 1.
+//        All values are taken from PDG, Physical Constants Table 1.1, 2014.
 // \author <cullenms@fnal.gov>
 
-/// G_F, the Fermi Constant in GeV^-2. (PDG, Physical Constants, 2014).
+namespace osc {
+namespace constants {
+
+/// G_F, the Fermi Constant in GeV^-2.
 const double kFermiConstant = 1.1663787e-5;
+
+/// N_A, Avogadro's number in mol^-1 (or if you prefer, electrons/mol when thinking about the matter effect).
+const double kAvogadroConstant = 6.02214129e23;
+
+/// c, the speed of light (unitless). Multiply by c in natural units to convert s to m.
+const double kSpeedOfLight = 299792458;
+
+/// hbar, reduced Planck's constant (unitless). Multiply by hbar in natural units to convert invese seconds to joules.
+const double kReducedPlanckConstant = 1.054571726e-34;
+
+/// e, the elementary charge (J/eV).
+const double kElementaryCharge = 1.602176565e-19;
+
+/// Unit conversion: m^-1 to eV.
+const double kInversemToeV =
+    kSpeedOfLight          // 1 m^-1 = SpeedOfLight s^-1.
+  * kReducedPlanckConstant // 1 s^-1 = ReducedPlanckConstant J.
+  / kElementaryCharge;     // ElementaryCharge J^-1 = eV.
+
+/// Given a matter density, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
+const double kMatterDensityToEffect =
+    2 * sqrt(2) * kFermiConstant * 1e-18 // The 1e-18 converts the Fermi constant from GeV^-2 to eV^-2.
+  * kAvogadroConstant                    // 1 mol = 1 AvogadroConstant.
+  * pow(kInversemToeV*100,3);
+
+}
+}
 
 #endif // OSCLIB_CONSTANTS
 

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -1,0 +1,14 @@
+
+#ifndef OSCLIB_CONSTANTS
+#define OSCLIB_CONSTANTS
+
+// \file Constants.h
+// \brief Keep important physical constants and unit conversions in one place.
+//        All values use the natural units system such that hbar = c = 1.
+// \author <cullenms@fnal.gov>
+
+/// G_F, the Fermi Constant in GeV^-2. (PDG, Physical Constants, 2014).
+const double kFermiConstant = 1.1663787e-5;
+
+#endif // OSCLIB_CONSTANTS
+

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -40,6 +40,12 @@ const double kMatterDensityToEffect =
   * kAvogadroConstant                    // 1 mol = 1 AvogadroConstant.
   * pow(kInversemToeV*100,3);
 
+/// Unit conversion: GeV to eV.
+const double kGeVToeV = 1e9;
+
+/// Unit conversion: km to m.
+const double kkmTom = 1e3;
+
 }
 }
 

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -13,6 +13,12 @@
 namespace osc {
 namespace constants {
 
+/// Unit conversion: GeV to eV.
+const double kGeVToeV = 1e9;
+
+/// Unit conversion: km to m.
+const double kkmTom = 1e3;
+
 /// G_F, the Fermi Constant in GeV^-2.
 const double kFermiConstant = 1.1663788e-5;
 
@@ -36,15 +42,9 @@ const double kInversemToeV =
 
 /// Given a matter density, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
 const double kMatterDensityToEffect =
-    sqrt(2) * kFermiConstant * 1e-18 // The 1e-18 converts the Fermi constant from GeV^-2 to eV^-2.
-  * kAvogadroConstant                    // 1 mol = 1 AvogadroConstant.
+    sqrt(2) * kFermiConstant * pow(kGeVToeV,2) // The 1e-18 converts the Fermi constant from GeV^-2 to eV^-2.
+  * kAvogadroConstant                          // 1 mol = 1 AvogadroConstant.
   * pow(kInversemToeV*100,3);
-
-/// Unit conversion: GeV to eV.
-const double kGeVToeV = 1e9;
-
-/// Unit conversion: km to m.
-const double kkmTom = 1e3;
 
 }
 }

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -14,37 +14,38 @@ namespace osc {
 namespace constants {
 
 /// Unit conversion: GeV to eV.
-const double kGeVToeV = 1e9;
+constexpr inline double kGeVToeV = 1e9;
 
 /// Unit conversion: km to m.
-const double kkmTom = 1e3;
+constexpr inline double kkmTom = 1e3;
 
 /// G_F, the Fermi Constant in GeV^-2.
-const double kFermiConstant = 1.1663788e-5;
+constexpr inline double kFermiConstant = 1.1663788e-5;
 
 /// N_A, Avogadro's number in mol^-1 (or if you prefer, electrons/mol when thinking about the matter effect).
-const double kAvogadroConstant = 6.02214076e23;
+constexpr inline double kAvogadroConstant = 6.02214076e23;
 
 /// c, the speed of light (m/s = unitless). Multiply by c in natural units to convert s to m.
-const double kSpeedOfLight = 299792458;
+constexpr inline double kSpeedOfLight = 299792458;
 
 /// hbar, reduced Planck's constant (GeV*s = unitless). Multiply by hbar in natural units to convert s^-1 to GeV.
-const double kReducedPlanckConstant = 6.582119569e-25;
+constexpr inline double kReducedPlanckConstant = 6.582119569e-25;
 
 /// Number of electrons per nucleon in a typical atom. Used for computing the matter effect.
-const double kZPerA = 0.5;
+constexpr inline double kZPerA = 0.5;
 
 /// Unit conversion: m^-1 to eV.
-const double kInversemToeV =
+constexpr inline double kInversemToeV =
     kSpeedOfLight          // 1 m^-1 = SpeedOfLight s^-1.
   * kReducedPlanckConstant // 1 s^-1 = ReducedPlanckConstant GeV.
   * kGeVToeV;              // Finally convert GeV to eV.
 
+// std::pow would be more readable, but it isn't constexpr until C++26.
 /// Given a matter density of electrons, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
-const double kMatterDensityToEffect =
-    sqrt(2) * kFermiConstant * pow(kGeVToeV,-2)
+constexpr inline double kMatterDensityToEffect =
+    M_SQRT2 * kFermiConstant * 1/(kGeVToeV*kGeVToeV)
   * kAvogadroConstant                          // 1 mol = 1 AvogadroConstant.
-  * pow(kInversemToeV*100,3);
+  * (kInversemToeV*100)*(kInversemToeV*100)*(kInversemToeV*100);
 
 }
 }

--- a/OscLib/Constants.h
+++ b/OscLib/Constants.h
@@ -42,7 +42,7 @@ const double kInversemToeV =
 
 /// Given a matter density, rho in mol/cm^3, multiply by 2*sqrt(2)*FermiConstant and convert units to eV.
 const double kMatterDensityToEffect =
-    sqrt(2) * kFermiConstant * pow(kGeVToeV,2) // The 1e-18 converts the Fermi constant from GeV^-2 to eV^-2.
+    sqrt(2) * kFermiConstant * pow(kGeVToeV,-2)
   * kAvogadroConstant                          // 1 mol = 1 AvogadroConstant.
   * pow(kInversemToeV*100,3);
 

--- a/OscLib/OscCalc.cxx
+++ b/OscLib/OscCalc.cxx
@@ -12,6 +12,8 @@
 #include <iostream>
 #include <cmath>
 
+#include "OscLib/Constants.h"
+
 #include "TF1.h"
 #include "TMath.h"
 
@@ -154,10 +156,8 @@ namespace osc {
     fcos_sq_2th23 = fcos_2th23*fcos_2th23;
 
     static const double ZperA = 0.5; // e- per nucleon
-    static const double G_F = 1.16637E-23; // eV^-2
-    static const double hbar_c_eV_cm = 1.97326938E-5; // eV-cm
 
-    fV = TMath::Sqrt2()*G_F*fRho*ZperA*TMath::Na()*hbar_c_eV_cm*hbar_c_eV_cm*hbar_c_eV_cm;
+    fV = constants::kMatterDensityToEffect*fRho*ZperA;
 
     fUpdated = true;
   }
@@ -165,14 +165,11 @@ namespace osc {
   // --------------------------------------------
   void OscCalc::UpdateEDep(double E, bool antinu, bool fliptime)
   {
-    static const double hbar_c_eV_km = 1.97326938E-10; // eV-km
-    static const double eVPerGeV = 1E9;
-
     int s = (antinu)?-1:1;
     int t = (fliptime)?-1:1;
 
-    fA = s*2*fV*E*eVPerGeV/fDmsq31;
-    fD = fDmsq31*fL/(4*E*eVPerGeV*hbar_c_eV_km);
+    fA = s*2*fV*E*constants::kGeVToeV/fDmsq31;
+    fD = fDmsq31*fL*constants::kkmTom/(4*constants::kInversemToeV*constants::kGeVToeV*E);
 
     fdCPproxy = s*t*fdCP;
     fsin_dCPproxy = sin(fdCPproxy);

--- a/OscLib/OscCalc.cxx
+++ b/OscLib/OscCalc.cxx
@@ -155,9 +155,7 @@ namespace osc {
     fcos_sq_2th13 = fcos_2th13*fcos_2th13;
     fcos_sq_2th23 = fcos_2th23*fcos_2th23;
 
-    static const double ZperA = 0.5; // e- per nucleon
-
-    fV = constants::kMatterDensityToEffect*fRho*ZperA;
+    fV = constants::kMatterDensityToEffect*fRho*constants::kZPerA;
 
     fUpdated = true;
   }

--- a/OscLib/OscCalcAnalytic.cxx
+++ b/OscLib/OscCalcAnalytic.cxx
@@ -205,9 +205,8 @@ namespace osc::analytic
   //---------------------------------------------------------------------------
   template<class T> double _OscCalc<T>::Hmat()
   {
-    // Perform unit conversions, including the Fermi constant, and divide by 2 because
-    //   the density of electrons is 0.5 the density of matter (in mol/cm^3).
-    return constants::kMatterDensityToEffect*this->fRho/2;
+    // Perform unit conversions, including the Fermi constant, and convert density of nucleons to electrons.
+    return constants::kMatterDensityToEffect*this->fRho*constants::kZPerA;
   }
 
   //---------------------------------------------------------------------------

--- a/OscLib/OscCalcDMP.h
+++ b/OscLib/OscCalcDMP.h
@@ -11,16 +11,6 @@
 
 using namespace Eigen;
 
-  // Unit conversion constants
-  //static const double kKm2eV  = 5.06773103202e+09; ///< km to eV^-1
-  //static const double kK2     = 4.62711492217e-09; ///< mole/GeV^2/cm^3 to eV
-  //static const double kGeV2eV = 1.0e+09;           ///< GeV to eV
-  //static const double kGf     = 1.166371e-5; //G_F in units of GeV^-2
-  //static const double eVsqkm_to_GeV = 1e-9 / 1.973269681602260e-7 * 1e3; // HS this is more like value in OscLib
-  //static const double YerhoE2a = 1.52e-4;
-
-
-
 namespace osc
 {
   /// \brief Helper struct for the cache. Might not need this

--- a/OscLib/OscCalcDumb.cxx
+++ b/OscLib/OscCalcDumb.cxx
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <cmath>
 
+#include "OscLib/Constants.h"
+
 namespace
 {
   template<class T> T sqr(T x) {return x*x;}
@@ -17,37 +19,38 @@ namespace osc
     const double ss2t13 = 0.1;     // sin^2(2theta_13)
     const double ss2t23 = 1.;      // maximal sin^2(2theta_23)
     const double ssth23 = 0.5;     // sin^2(theta_23) corresponding to above
+    const double k = constants::kkmTom / constants::kInversemToeV / constants::kGeVToeV / 4;
 
     // Signal
     if(abs(flavAfter) == 12 && abs(flavBefore) == 14){
       // Nue appearance
-      return ss2t13*ssth23*sqr(sin(1.267*ldm*L/E));
+      return ss2t13*ssth23*sqr(sin(k*ldm*L/E));
     }
     if(abs(flavAfter) == 14 && abs(flavBefore) == 14){
       // CC mu disappearance
-      return 1-ss2t23*sqr(sin(1.267*ldm*L/E));
+      return 1-ss2t23*sqr(sin(k*ldm*L/E));
     }
 
     // Background
     if(abs(flavAfter) == 12 && abs(flavBefore) == 12){
       // Beam nue
-      return 1-ss2t13*sqr(sin(1.267*ldm*L/E));
+      return 1-ss2t13*sqr(sin(k*ldm*L/E));
     }
     if(abs(flavAfter) == 14 && abs(flavBefore) == 12){
       // CC mu appearance
-      return ss2t13*ssth23*sqr(sin(1.267*ldm*L/E));
+      return ss2t13*ssth23*sqr(sin(k*ldm*L/E));
     }
     if(abs(flavAfter) == 16 && abs(flavBefore) == 14){
       //numu to nutau CC appearance
-      return (1-ss2t13)*ss2t23*sqr(sin(1.267*ldm*L/E));
+      return (1-ss2t13)*ss2t23*sqr(sin(k*ldm*L/E));
     }
     if(abs(flavAfter) == 16 && abs(flavBefore) == 12){
       //nue to nutau CC appearance
-      return ss2t13*(1-ssth23)*sqr(sin(1.267*ldm*L/E));
+      return ss2t13*(1-ssth23)*sqr(sin(k*ldm*L/E));
     }
     if(abs(flavAfter) == 16 && abs(flavBefore) == 16){
       //nutau to nutau CC disappearance
-      return 1-(ss2t23-ss2t23*ss2t13+ss2t13-ss2t13*ssth23)*sqr(sin(1.267*ldm*L/E));
+      return 1-(ss2t23-ss2t23*ss2t13+ss2t13-ss2t13*ssth23)*sqr(sin(k*ldm*L/E));
     }
 
     // Don't know what this is

--- a/OscLib/OscCalcGeneral.cxx
+++ b/OscLib/OscCalcGeneral.cxx
@@ -187,7 +187,7 @@ namespace osc
   {
     ComplexMat H = kZeroMat;
 
-    const double k = constants::kMatterDensityToEffect / constants::kInversemToeV * constants::kkmTom / 2;
+    const double k = constants::kMatterDensityToEffect / constants::kInversemToeV * constants::kkmTom * constants::kZPerA;
 
     H(0, 0) = k * Ne;
 

--- a/OscLib/OscCalcGeneral.cxx
+++ b/OscLib/OscCalcGeneral.cxx
@@ -25,6 +25,8 @@
 #include <cassert>
 #include <complex>
 
+#include "OscLib/Constants.h"
+
 namespace osc
 {
   const unsigned int kNumFlavours = 3;
@@ -159,8 +161,7 @@ namespace osc
                                const std::vector<long double>& mSq,
                                long double E)
   {
-    // Conversion factor for units
-    E /= 4*1.267;
+    E /= (constants::kkmTom / (constants::kInversemToeV * constants::kGeVToeV));
 
     assert(mSq.size() == kNumFlavours);
 
@@ -184,19 +185,14 @@ namespace osc
   // converted to antineutrinos by taking a minus sign.
   ComplexMat MatterHamiltonianComponent(long double Ne, long double emutau)
   {
-    // Need to convert avogadro's constant so that the total term comes out in
-    // units of inverse distance. Note that Ne will be specified in g/cm^-3
-    // I put the following into Wolfram Alpha:
-    // (fermi coupling constant)*((avogadro number)/cm^3)*(reduced planck constant)^2*(speed of light)^2
-    // And then multiplied by 1000 because we specify L in km not m.
-    const long double GF = 1.368e-4;
-
     ComplexMat H = kZeroMat;
 
-    H(0, 0) = sqrt(2)*GF*Ne;
+    const double k = constants::kMatterDensityToEffect / constants::kInversemToeV * constants::kkmTom / 2;
+
+    H(0, 0) = k * Ne;
 
     // Ignoring conjugates here because we assume e_mutau is real
-    H(1, 2) = H(2, 1) = emutau*sqrt(2)*GF*Ne;
+    H(1, 2) = H(2, 1) = emutau * k * Ne;
 
     return H;
   }

--- a/OscLib/OscCalcNuFast.cxx
+++ b/OscLib/OscCalcNuFast.cxx
@@ -151,7 +151,7 @@ namespace osc {
     // Compute the matter effect using the Fermi Constant and make sure Amatter is in eV^2.
     // The extra 1e9 here converts E in GeV to eV.
     const VT
-    Amatter = (Ye*rho*constants::kMatterDensityToEffect*1e9)*E,
+    Amatter = (Ye*rho*2*constants::kMatterDensityToEffect*1e9)*E,
     
     // calculate A, B, C, See, Tee, and part of Tmm
     C = Amatter * Tee,

--- a/OscLib/OscCalcNuFast.cxx
+++ b/OscLib/OscCalcNuFast.cxx
@@ -151,7 +151,7 @@ namespace osc {
     // Compute the matter effect using the Fermi Constant and make sure Amatter is in eV^2.
     // The extra 1e9 here converts E in GeV to eV.
     const VT
-    Amatter = (Ye*rho*2*constants::kMatterDensityToEffect*1e9)*E,
+    Amatter = (Ye*rho*2*constants::kMatterDensityToEffect*constants::kGeVToeV)*E,
     
     // calculate A, B, C, See, Tee, and part of Tmm
     C = Amatter * Tee,
@@ -218,8 +218,8 @@ namespace osc {
     // ----------------------- //
     // Get the kinematic terms //
     // ----------------------- //
-    // 1e-6 converts L/E in km/GeV to m/eV, then we convert m to eV-1.
-    Lover4E = ( 1e-6 / constants::kInversemToeV / 4) * (L/E),
+    // Convert L/E in km/GeV to m/eV, then we convert m to eV-1.
+    Lover4E = ( constants::kkmTom / constants::kGeVToeV / constants::kInversemToeV / 4) * (L/E),
     
     // DlambdaXY have units of eV^2.
     D21 = Dlambda21 * Lover4E,

--- a/OscLib/OscCalcNuFast.cxx
+++ b/OscLib/OscCalcNuFast.cxx
@@ -14,7 +14,7 @@ namespace osc {
   
   template<typename T>
   _OscCalcNuFast<T>::_OscCalcNuFast(void) :
-    fYe(0.5), fNNewton(0), fIsDirty(true)
+    fYe(0.5), fNNewton(1), fIsDirty(true)
     {}
   
   template<typename T>

--- a/OscLib/OscCalcNuFast.cxx
+++ b/OscLib/OscCalcNuFast.cxx
@@ -6,7 +6,6 @@
 #include "OscLib/OscCalcNuFast.h"
 
 #include <cassert>
-#include <cmath>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -149,8 +148,10 @@ namespace osc {
     See = Dmsq21+Dmsq31 - Dmsq21 * c13sqxs12sq - Dmsq31 * s13sq,
     Tee = Dmsq21 * Dmsq31 * (c13sq - c13sqxs12sq);
     
+    // Compute the matter effect using the Fermi Constant and make sure Amatter is in eV^2.
+    // The extra 1e9 here converts E in GeV to eV.
     const VT
-    Amatter = (Ye*rho*YerhoE2a) * E,
+    Amatter = (Ye*rho*constants::kMatterDensityToEffect*1e9)*E,
     
     // calculate A, B, C, See, Tee, and part of Tmm
     C = Amatter * Tee,
@@ -217,8 +218,10 @@ namespace osc {
     // ----------------------- //
     // Get the kinematic terms //
     // ----------------------- //
-    Lover4E = (eVsqkm_to_GeV_over4 * L) / E,
+    // 1e-6 converts L/E in km/GeV to m/eV, then we convert m to eV-1.
+    Lover4E = ( 1e-6 / constants::kInversemToeV / 4) * (L/E),
     
+    // DlambdaXY have units of eV^2.
     D21 = Dlambda21 * Lover4E,
     D32 = Dlambda32 * Lover4E,
 	  

--- a/OscLib/OscCalcNuFast.cxx
+++ b/OscLib/OscCalcNuFast.cxx
@@ -14,7 +14,7 @@ namespace osc {
   
   template<typename T>
   _OscCalcNuFast<T>::_OscCalcNuFast(void) :
-    fYe(0.5), fNNewton(1), fIsDirty(true)
+    fYe(constants::kZPerA), fNNewton(1), fIsDirty(true)
     {}
   
   template<typename T>
@@ -87,19 +87,14 @@ namespace osc {
   }
   
   template<typename T> T _OscCalcNuFast<T>::P(int from, int to, double E) {
-    //std::cout << "NuFast: Calling double overload." << std::endl;
     return _P<T>(from,to,E);
   }
   
-  template<typename T> Eigen::ArrayX<T> _OscCalcNuFast<T>::P(int from, int to, const Eigen::ArrayXd& E)
-  {
-    //std::cout << "NuFast: Calling Eigen::ArrayXd overload." << std::endl;
+  template<typename T> Eigen::ArrayX<T> _OscCalcNuFast<T>::P(int from, int to, const Eigen::ArrayXd& E) {
     return _P<Eigen::ArrayX<T>>(from,to,E);
   }
   
-  template<typename T> Eigen::ArrayX<T> _OscCalcNuFast<T>::P(int from, int to, const std::vector<double>& E)
-  {
-    //std::cout << "NuFast: Calling std::vector<double> overload (size = " << E.size() << ")." << std::endl;
+  template<typename T> Eigen::ArrayX<T> _OscCalcNuFast<T>::P(int from, int to, const std::vector<double>& E) {
     return P(from,to,Eigen::Map<const Eigen::ArrayXd>(E.data(),E.size()));
   }
   

--- a/OscLib/OscCalcNuFast.h
+++ b/OscLib/OscCalcNuFast.h
@@ -8,9 +8,11 @@
 //        See arXiv:2405.02400.
 // \author <cullenms@fnal.gov>
 
+#include <cmath>
 #include <string>
 
 #include "OscLib/Cache.h"
+#include "OscLib/Constants.h"
 #include "OscLib/IOscCalc.h"
 
 #include "TMD5.h"
@@ -92,10 +94,6 @@ namespace osc {
     
     /// Do we need to recompute the nontrivial energy-independent terms?
     mutable bool fIsDirty;
-    
-    // Constants for unit conversions, using Fermi constant for matter effect.
-    double const eVsqkm_to_GeV_over4 = 1e-9 / 1.97327e-7 * 1e3 / 4;
-    double const YerhoE2a = 1.52e-4;
   };
   
   typedef _OscCalcNuFast<double> OscCalcNuFast;

--- a/OscLib/OscCalcNuFast.h
+++ b/OscLib/OscCalcNuFast.h
@@ -47,7 +47,7 @@ namespace osc {
     virtual void SetTh13  (const T& th13  ) override;
     virtual void SetTh23  (const T& th23  ) override;
     virtual void SetdCP   (const T& dCP   ) override;
-    /// Electron density in matter used by NuFast (default = 0.5).
+    /// Electron density in matter used by NuFast (default = constants::kZPerA).
     virtual void SetYe    (double Ye      ) { this->fIsDirty = true; this->fYe = Ye; }
     /// Number of Newton steps to improve eigen{value}{vector} convergence (default = 0 seems fine, use 1 or 2 if you need super accuracy).
     virtual void SetNNewton(double nNewton) { this->fIsDirty = true; this->fNNewton = nNewton; }

--- a/OscLib/OscCalcPMNS.cxx
+++ b/OscLib/OscCalcPMNS.cxx
@@ -7,6 +7,8 @@
 
 #include "OscLib/OscCalcPMNS.h"
 
+#include "OscLib/Constants.h"
+
 namespace osc
 {
   // --------------------------------------------------------------------------
@@ -57,8 +59,7 @@ namespace osc
 
     if(fPropDirty || E != fPrevE){
       fPMNS.Reset();
-      // Assume Z/A=0.5
-      const double Ne = this->fRho/2;
+      const double Ne = this->fRho * constants::kZPerA;
       fPMNS.PropMatter(this->fL, E, Ne, anti);
 
       fPropDirty = false;

--- a/OscLib/OscCalcPMNSOpt.cxx
+++ b/OscLib/OscCalcPMNSOpt.cxx
@@ -7,6 +7,8 @@
 
 #include "OscLib/OscCalcPMNSOpt.h"
 
+#include "OscLib/Constants.h"
+
 namespace osc
 {
   //---------------------------------------------------------------------------
@@ -95,8 +97,7 @@ namespace osc
       // Cache results for all nine flavour combinations
       for(int ii = 0; ii < 3; ++ii){
         calc.pmns->ResetToFlavour(ii);
-        // Assume Z/A=0.5
-        const double Ne = this->fRho/2;
+        const double Ne = this->fRho * constants::kZPerA;
         calc.pmns->PropMatter(this->fL, E, Ne, anti);
         for(int jj = 0; jj < 3; ++jj){
           calc.P[ii][jj] = calc.pmns->P(jj);

--- a/OscLib/OscCalcPMNSOptEigen.cxx
+++ b/OscLib/OscCalcPMNSOptEigen.cxx
@@ -348,7 +348,7 @@ namespace osc {
 					   const OscParameters & params) const
   {
     auto lv = 2 * constants::kGeVToeV * E / params.Dmsq31();
-    auto kr2GNe = constants::kMatterDensityToEffect * params.rho/2;
+    auto kr2GNe = constants::kMatterDensityToEffect * params.rho * constants::kZPerA;
 
     Eigen::Matrix3cd green_eggs(ham);
     green_eggs.triangularView<Eigen::Upper>()/=lv;

--- a/OscLib/OscCalcPMNSOptEigen.cxx
+++ b/OscLib/OscCalcPMNSOptEigen.cxx
@@ -4,6 +4,8 @@
 
 #include "TMD5.h"
 
+#include "OscLib/Constants.h"
+
 //#include "OscLib/PMNSOpt.cxx"
 
 //#include "zhetrd3.cxx"
@@ -266,7 +268,7 @@ namespace osc {
 				     Eigen::Vector3d const & evals,
 				     const OscParameters & params) const
   {
-    const Eigen::Array3d temp = evals.array()*kKm2eV*(-1)*params.L;
+    const Eigen::Array3d temp = evals.array()*constants::kkmTom/constants::kInversemToeV*(-1)*params.L;
     //Eigen::Array3d temp(evals.array());
 
     //// propagation phase
@@ -345,9 +347,9 @@ namespace osc {
 					   const int & anti,
 					   const OscParameters & params) const
   {
-    double lv = 2 * kGeV2eV*E / params.Dmsq31();  // Osc. length in eV^-1
-    double kr2GNe = kK2*M_SQRT2*kGf * params.rho/2; // Matter potential in eV
-    
+    auto lv = 2 * constants::kGeVToeV * E / params.Dmsq31();
+    auto kr2GNe = constants::kMatterDensityToEffect * params.rho/2;
+
     Eigen::Matrix3cd green_eggs(ham);
     green_eggs.triangularView<Eigen::Upper>()/=lv;
 
@@ -369,8 +371,8 @@ namespace osc {
 					       const double & E,
 					       const OscParameters & params) const
   {
-    double lv = 2 * kGeV2eV*E / params.Dmsq31();  // Osc. length in eV^-1
-    double kr2GNe = kK2*M_SQRT2*kGf * params.rho/2; // Matter potential in eV
+    auto lv = 2 * constants::kGeVToeV * E / params.Dmsq31();
+    auto kr2GNe = constants::kMatterDensityToEffect * params.rho/2;
     
     Eigen::Matrix3cd green_eggs(ham);
     green_eggs.triangularView<Eigen::Upper>()/=lv;
@@ -387,8 +389,8 @@ namespace osc {
 					   const double & E,
 					   const OscParameters & params) const
   {
-    double lv = 2 * kGeV2eV*E / params.Dmsq31();  // Osc. length in eV^-1
-    double kr2GNe = kK2*M_SQRT2*kGf * params.rho/2; // Matter potential in eV
+    auto lv = 2 * constants::kGeVToeV * E / params.Dmsq31();
+    auto kr2GNe = constants::kMatterDensityToEffect * params.rho/2;
     
     Eigen::Matrix3cd green_eggs(ham);
     green_eggs.triangularView<Eigen::Upper>()/=lv;
@@ -410,8 +412,8 @@ namespace osc {
 					    const int & anti,
 					    const OscParameters & params) const
   {
-    double lv = 2 * kGeV2eV*E / params.Dmsq31();  // Osc. length in eV^-1
-    double kr2GNe = kK2*M_SQRT2*kGf * params.rho/2; // Matter potential in eV
+    auto lv = 2 * constants::kGeVToeV * E / params.Dmsq31();
+    auto kr2GNe = constants::kMatterDensityToEffect * params.rho/2;
 
     auto HLV = BuildHam(params);
     HLV.triangularView<Eigen::Upper>()/=lv;

--- a/OscLib/OscCalcPMNSOptEigen.h
+++ b/OscLib/OscCalcPMNSOptEigen.h
@@ -17,14 +17,6 @@
   static std::complex<double> zero(0.0,0.0);
   static std::complex<double> one (1.0,0.0);
 
-  // Unit conversion constants
-  static const double kKm2eV  = 5.06773103202e+09; ///< km to eV^-1
-  static const double kK2     = 4.62711492217e-09; ///< mole/GeV^2/cm^3 to eV
-  static const double kGeV2eV = 1.0e+09;           ///< GeV to eV
-
-  //G_F in units of GeV^-2
-  static const double kGf     = 1.166371e-5;
-
 namespace osc
 {
   /// \brief Helper struct for the cache. Might not need this

--- a/OscLib/OscCalcPMNS_CPT.cxx
+++ b/OscLib/OscCalcPMNS_CPT.cxx
@@ -6,6 +6,8 @@
 /////////////////////////////////////////////////////////////////////////////
 #include "OscLib/OscCalcPMNS_CPT.h"
 
+#include "OscLib/Constants.h"
+
 #include "TMD5.h"
 
 #include <cassert>
@@ -56,8 +58,7 @@ namespace osc
     
         if(fPropDirty_bar || E != fPrevE_bar){
           fPMNS_bar.Reset();
-          // Assume Z/A=0.5
-          const double Ne = fRho/2;
+          const double Ne = fRho * constants::kZPerA;
           fPMNS_bar.PropMatter(fL, E, Ne, anti);
     
           fPropDirty_bar = false;
@@ -89,8 +90,7 @@ namespace osc
     
         if(fPropDirty || E != fPrevE){
           fPMNS.Reset();
-          // Assume Z/A=0.5
-          const double Ne = fRho/2;
+          const double Ne = fRho * constants::kZPerA;
           fPMNS.PropMatter(fL, E, Ne, anti);
     
           fPropDirty = false;

--- a/OscLib/OscCalcPMNS_NSI.cxx
+++ b/OscLib/OscCalcPMNS_NSI.cxx
@@ -1,5 +1,7 @@
 #include "OscLib/OscCalcPMNS_NSI.h"
 
+#include "OscLib/Constants.h"
+
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
@@ -101,8 +103,7 @@ namespace osc
 
 
     fPMNS_NSI.ResetToFlavour(i);
-    // Assume Z/A=0.5
-    const double Ne = fRho/2;
+    const double Ne = fRho * constants::kZPerA;
     fPMNS_NSI.PropMatter(fL, E, Ne, anti);
     return fPMNS_NSI.P(j);
   }

--- a/OscLib/OscCalcSterile.cxx
+++ b/OscLib/OscCalcSterile.cxx
@@ -1,5 +1,7 @@
 #include "OscLib/OscCalcSterile.h"
 
+#include "OscLib/Constants.h"
+
 #include "TMD5.h"
 
 #include <cassert>
@@ -136,8 +138,7 @@ namespace osc
 
     if (fDirty) {
       fPMNS_Sterile->ResetToFlavour(i);      
-      // Assume Z/A=0.5
-      const double Ne = fRho/2;
+      const double Ne = fRho * constants::kZPerA;
       fPMNS_Sterile->PropMatter(fL, E, Ne, anti);
     }
     

--- a/OscLib/OscCalcSterileEigen.cxx
+++ b/OscLib/OscCalcSterileEigen.cxx
@@ -1,5 +1,6 @@
 #include "OscLib/OscCalcSterileEigen.h"
 #include "OscLib/OscCalcPMNSOptEigen.h"
+#include "OscLib/Constants.h"
 
 #include <iostream>
 #include <cassert>
@@ -309,8 +310,8 @@ namespace osc
     }
     else return;
 
-    double lv = 2 * kGeV2eV*E;          // 2E in eV 
-    double kr2GNe = kK2*M_SQRT2*kGf*Ne; // Matter potential in eV
+    double lv = 2 * constants::kGeVToeV * E;
+    double kr2GNe = constants::kMatterDensityToEffect * Ne;
 
     fHmsMat = fHms;
     
@@ -336,7 +337,7 @@ namespace osc
     this->SolveHam(E, Ne, anti);
 
     fNuState = fEig.eigenvectors()*(
-  				  fEig.eigenvalues().unaryExpr([L] (double x) { double sinx(0), cosx(0); _sincos(-kKm2eV*L*x,sinx,cosx); return complex(cosx, sinx);}
+  				  fEig.eigenvalues().unaryExpr([L] (double x) { double sinx(0), cosx(0); _sincos(-constants::kkmTom/constants::kInversemToeV*L*x,sinx,cosx); return complex(cosx, sinx);}
   				  ).asDiagonal())*fEig.eigenvectors().adjoint()*fNuState;
   }
 

--- a/OscLib/OscCalcSterileEigen.cxx
+++ b/OscLib/OscCalcSterileEigen.cxx
@@ -390,7 +390,7 @@ namespace osc
     assert(i >= 0 && j >= 0);
 
     ResetToFlavour(i);
-    PropMatter(fL, E, fRho/2, anti);
+    PropMatter(fL, E, fRho*constants::kZPerA, anti);
     if (j == 3) return GetP(0) + GetP(1) + GetP(2);
     else return GetP(j);
   }

--- a/OscLib/PMNS.cxx
+++ b/OscLib/PMNS.cxx
@@ -511,8 +511,7 @@ void _PMNS<T>::PropVacuum(double L, double E, int anti)
 template <typename T>
 void _PMNS<T>::PropMatter(double L, double E, double Ne, int anti)
 {
-//  static const double  Gf = 1.166371E-5; // G_F in units of GeV^-2
-static const double  Gf = constants::kFermiConstant;
+  static const double  Gf = constants::kFermiConstant;
   int i, j;
   complex twoEH[3][3];
   complex X[3][3];

--- a/OscLib/PMNS.cxx
+++ b/OscLib/PMNS.cxx
@@ -41,6 +41,7 @@
 #include "OscLib/Stan.h"
 #endif
 
+#include "OscLib/Constants.h"
 #include "OscLib/PMNS.h"
 
 #include <cstdlib>
@@ -57,9 +58,8 @@ template<typename T>
 auto one()  { return std::complex<T>(1.0,0.0); }
 
 // Unit conversion constants
-static const double kK1     = 2.53386551601e-00; ///< (1/2)*(1000/hbarc)
-static const double kK2     = 4.62711492217e-09; ///< mole/GeV^2/cm^3 to eV
-static const double kGeV2eV = 1.0E9;             ///< GeV to eV
+static const double kK1 = constants::kkmTom / constants::kGeVToeV / constants::kInversemToeV / 2;
+static const double kK2 = constants::kAvogadroConstant * pow(constants::kInversemToeV*100,3) / pow(constants::kGeVToeV,2);
 
 //......................................................................
 
@@ -279,7 +279,7 @@ void _PMNS<T>::EvalEqn5(complex       twoEH[][3],
 		   double        Ne)
 {
   int j, k;
-  T         k2r2GNeE = kK2*2.0*M_SQRT2*Gf*Ne*(kGeV2eV*E);
+  T         k2r2GNeE = kK2*2.0*M_SQRT2*Gf*Ne*(constants::kGeVToeV*E);
   for (k=0; k<3; ++k) {
     for (j=0; j<3; ++j) {
       twoEH[k][j] = zero<T>();
@@ -429,7 +429,7 @@ void _PMNS<T>::EvalEqn22(T& alpha,
                          const complex U[][3])
 {
   // 2*sqrt(2)*Gf*Ne*E in units of eV^2
-  auto k2r2EGNe = kK2*2.0*M_SQRT2*Gf*Ne*(kGeV2eV*E);
+  auto k2r2EGNe = kK2*2.0*M_SQRT2*Gf*Ne*(constants::kGeVToeV*E);
   
   alpha = k2r2EGNe + dmsqr[0][1] + dmsqr[0][2];
   
@@ -511,7 +511,8 @@ void _PMNS<T>::PropVacuum(double L, double E, int anti)
 template <typename T>
 void _PMNS<T>::PropMatter(double L, double E, double Ne, int anti)
 {
-  static const double  Gf = 1.166371E-5; // G_F in units of GeV^-2
+//  static const double  Gf = 1.166371E-5; // G_F in units of GeV^-2
+static const double  Gf = constants::kFermiConstant;
   int i, j;
   complex twoEH[3][3];
   complex X[3][3];

--- a/OscLib/PMNSOpt.cxx
+++ b/OscLib/PMNSOpt.cxx
@@ -218,8 +218,8 @@ void _PMNSOpt<T>::SolveHam(double E, double Ne, int anti)
   }
   else return;
 
-  auto lv = 2 * kGeV2eV*E / fDm31;  // Osc. length in eV^-1
-  auto kr2GNe = kK2*M_SQRT2*kGf*Ne; // Matter potential in eV
+  auto lv = 2 * constants::kGeVToeV * E / fDm31;
+  auto kr2GNe = constants::kMatterDensityToEffect * Ne;
 
   // Finish building Hamiltonian in matter with dimension of eV
   complex A[3][3];
@@ -266,8 +266,8 @@ void _PMNSOpt<T>::PropMatter(double L, double E, double Ne, int anti)
 
   // Propagate neutrino state
   for(int j=0;j<3;j++){
-    auto s = sin(-fEval[j] * kKm2eV * L);
-    auto c = cos(-fEval[j] * kKm2eV * L);
+    auto s = sin(-fEval[j] / constants::kInversemToeV * constants::kkmTom * L);
+    auto c = cos(-fEval[j] / constants::kInversemToeV * constants::kkmTom * L);
 
     complex jPart = complex(c, s) * nuComp[j];
     for(int i=0;i<3;i++){
@@ -329,9 +329,9 @@ void _PMNSOpt<T>::SetVacuumEigensystem(double E, int anti)
   fEvec[2][2] =  complex(c23*c13, 0);
 
   fEval[0] = 0;
-  fEval[1] = fDm21 / (2 * kGeV2eV*E);
-  fEval[2] = fDm31 / (2 * kGeV2eV*E);
 
+  fEval[1] = fDm21 / (2 * constants::kGeVToeV * E);
+  fEval[2] = fDm31 / (2 * constants::kGeVToeV * E);
 }
 
 ///.....................................................................
@@ -355,7 +355,7 @@ void _PMNSOpt<T>::PropVacuum(double L, double E, int anti)
     }
   }
 
-  const T km2EvL = kKm2eV*L;  // needed for the templated multiplication below to work
+  const T km2EvL = constants::kkmTom / constants::kInversemToeV * L; // needed for the templated multiplication below to work
   for(int i=0;i<3;i++){
     fNuState[i] = 0;
     for(int j=0;j<3;j++){

--- a/OscLib/PMNSOpt.h
+++ b/OscLib/PMNSOpt.h
@@ -34,17 +34,10 @@
 #include <list>
 #include <complex>
 
+#include "OscLib/Constants.h"
+
 namespace osc
 {
-
-  // Unit conversion constants
-  static const double kKm2eV  = 5.06773103202e+09; ///< km to eV^-1
-  static const double kK2     = 4.62711492217e-09; ///< mole/GeV^2/cm^3 to eV
-  static const double kGeV2eV = 1.0e+09;           ///< GeV to eV
-
-  //G_F in units of GeV^-2
-  static const double kGf     = 1.166371e-5;
-
   /// Optimized version of \ref PMNS
   template <typename T>
   class _PMNSOpt

--- a/OscLib/PMNS_DMP.h
+++ b/OscLib/PMNS_DMP.h
@@ -1,6 +1,7 @@
 #ifndef PMNSDMP_H
 #define PMNSDMP_H
 
+#include "OscLib/Constants.h"
 #include "OscLib/OscParameters.h"
 #include <Eigen/Eigen>
 using namespace Eigen;
@@ -8,11 +9,6 @@ using namespace Eigen;
 
 namespace osc 
 {
-
-    //static double eVsqkm_to_GeV = 1e-9 / 1.97327e-7 * 1e3;
-    static double eVsqkm_to_GeV = 1e-9 / 1.973269681602260e-7 * 1e3; // HS this is more like value in OscLib
-    static double YerhoE2a = 1.52e-4;
-
     //struct OscParameters;
 
 
@@ -29,8 +25,8 @@ namespace osc
                   double const rho,
                   double const L) :
         _ENERGIES(energies),
-        _AA(0.5 * rho * YerhoE2a * energies),
-        _L4E(eVsqkm_to_GeV * L / (4*energies)),
+        _AA(rho * constants::kMatterDensityToEffect * constants::kGeVToeV * energies),
+        _L4E((constants::kkmTom / constants::kGeVToeV / constants::kInversemToeV) * L / (4*energies)),
         _ONE(ArrayXd::Ones(energies.rows())),
         _Dmsqee(0), _Dmsq21(0), _Dmsq31(0), _c13(0), _s13(0), _c23(0), _s23(0),
         _c213(0), _s213(0), _c212(0), _s212(0),

--- a/OscLib/PMNS_NSI.cxx
+++ b/OscLib/PMNS_NSI.cxx
@@ -85,8 +85,8 @@ void PMNS_NSI::SolveHam(double E, double Ne, int anti)
   }
   else return;
 
-  double lv = 2 * kGeV2eV*E / fDm31;  // Osc. length in eV^-1 
-  double kr2GNe = kK2*M_SQRT2*kGf*Ne; // Matter potential in eV
+  double lv = 2 * constants::kGeVToeV * E / fDm31;  // Osc. length in eV^-1 
+  double kr2GNe = constants::kMatterDensityToEffect * Ne; // Matter potential in eV
 
   // Finish build Hamiltonian in matter with dimension of eV
   complex A[3][3];

--- a/OscLib/PMNS_NSI.h
+++ b/OscLib/PMNS_NSI.h
@@ -15,6 +15,7 @@
 #include <list>
 #include <complex>
 
+#include "OscLib/Constants.h"
 #include "OscLib/PMNSOpt.h"
 
 namespace osc {

--- a/OscLib/PMNS_Sterile.cxx
+++ b/OscLib/PMNS_Sterile.cxx
@@ -22,6 +22,8 @@
 #include <cassert>
 #include <stdlib.h>
 
+#include "OscLib/Constants.h"
+
 #include <gsl/gsl_complex.h>
 #include <gsl/gsl_complex_math.h>
 #include <gsl/gsl_matrix.h>
@@ -78,14 +80,6 @@ namespace osc
 // Some useful complex numbers
 static std::complex<double> zero(0.0,0.0);
 static std::complex<double> one (1.0,0.0);
-
-// Unit conversion constants
-static const double kKm2eV  = 5.06773103202e+09; ///< km to eV^-1
-static const double kK2     = 4.62711492217e-09; ///< mole/GeV^2/cm^3 to eV
-static const double kGeV2eV = 1.0e+09;           ///< GeV to eV
-
-//G_F in units of GeV^-2
-static const double kGf     = 1.166371E-5;
 
 using namespace std;
 
@@ -401,8 +395,8 @@ void PMNS_Sterile::SolveHam(double E, double Ne, int anti)
   }
   else return;
 
-  double lv = 2 * kGeV2eV*E;          // 2E in eV 
-  double kr2GNe = kK2*M_SQRT2*kGf*Ne; // Matter potential in eV
+  double lv = 2 * constants::kGeVToeV * E;
+  double kr2GNe = constants::kMatterDensityToEffect * Ne;
 
   // Finish building Hamiltonian in matter with dimension of eV
 
@@ -460,7 +454,7 @@ void PMNS_Sterile::PropMatter(double L, double E, double Ne, int anti)
       gsl_complex buf = gsl_matrix_complex_get(d->fEvec,i,j);
       complex evecij = complex( GSL_REAL(buf), GSL_IMAG(buf) );
       complex iEval(0.0,gsl_vector_get(d->fEval,j));
-      fNuState[i] +=  exp(-iEval * kKm2eV*L) * nuComp[j] * evecij;
+      fNuState[i] +=  exp(-iEval * constants::kkmTom / constants::kInversemToeV * L) * nuComp[j] * evecij;
     }
   }
 


### PR DESCRIPTION
Currently, different oscillation calculators internally define their own fundamental constants and unit conversions. This PR is an in-progress effort to make a new header file to keep all physical constants (based on 2024 PDG values) in one place and to edit calculators to point to the new header. I'm making the PR now so that others can see my progress as I make it and comment on my implementation. If you think I should do this differently, please let me know!

**Merging this PR would change oscillation predictions** very slightly. Before un-marking the PR as draft, I'll check "before-and-after" oscillation spectra to understand how large of an effect the changes have and to make sure I didn't make mistakes.

Progress editing calculators:
- [x] `OscCalc`
- [x] `OscCalcAnalytic`
- [x] `OscCalcDMP`, including `PMNS_DMP.h`/`cxx`
- [x] `OscCalcDumb`
- [x] `OscCalcGeneral`
- [x] `OscCalcNuFast`
- [x] `OscCalcPMNS`, including `PMNS.h`/`cxx`
- [x] `OscCalcPMNSOpt`, including `PMNSOpt.h`/`cxx`
- [x] `OscCalcPMNSOptEigen`
- [x] `OscCalcPMNS_NSI`, including `PMNS_NSI.h`/`cxx` (need to check with people who know about NSI stuff to make sure I do it correctly)
- [x] `OscCalcSterile`, `OscCalcSterileBeam`, and `OscCalcSterileEigen`, including `PMNS_Sterile.h`/`cxx`