### PR TITLE
drop down to sundials v6_1_1 dependency if we want stan.

### DIFF
--- a/jenkins/dependencies.sh
+++ b/jenkins/dependencies.sh
@@ -40,5 +40,5 @@ fi
 if [ $WANTSTAN == yes ]
 then
     echo stan_math v4_9_0a
-    echo sundials v7_1_1
+    echo sundials v6_1_1
 fi

--- a/jenkins/make_table.sh
+++ b/jenkins/make_table.sh
@@ -8,7 +8,7 @@ echo VERSION=$TAG
 echo
 echo
 
-for EXPT in n313 n315 n316
+for EXPT in n313 n315 n316 n319
 do
     for OPT in debug prof
     do


### PR DESCRIPTION
Also noticed when making table, didn't catch the n319 qualifier.

Need an osclib that depends on sundials v6_1_1 