### PR TITLE
Fix CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,10 @@ if(STAN)
   endif()
   if(USE_STAN_THREADS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTAN_THREADS")
-  endif
+  endif()
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
   find_package(stan_math REQUIRED)
+  find_package(SUNDIALS REQUIRED)
   find_package(TBB REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(osclib VERSION 0.27)
+project(osclib VERSION 1.00)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/OscLib/CMakeLists.txt
+++ b/OscLib/CMakeLists.txt
@@ -1,6 +1,6 @@
 # optional stan dependency
 if (STAN)
-  set (STAN_TARGETS stan_math::stan_math TBB::tbb)
+  set (STAN_TARGETS stan_math::stan_math SUNDIALS::kinsol_shared TBB::tbb)
 endif (STAN)
 
 cet_make_library(LIBRARY_NAME OscLib

--- a/OscLib/IOscCalc.h
+++ b/OscLib/IOscCalc.h
@@ -10,7 +10,10 @@
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <Eigen/Eigen>
+#pragma GCC diagnostic pop
 
 class TMD5;
 


### PR DESCRIPTION
i've been revisiting the OscLib CMake build for Spack 1.0, and it looks like recent changes to the code introduced some issues to the CMake build. this PR makes the following changes:
- fix a syntax error in the top-level `CMakeLists.txt`
- set the correct OscLib version in `CMakeLists.txt`
- find the SUNDIALS package using its CMake config
- add the `SUNDIALS::kinsol_shared` target when building the Stan variant
- add a compiler directive to ignore a warning from one of the Eigen headers that gets treated as an error, breaking the build