### PR TITLE
Update cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(osclib VERSION 1.00)
+project(osclib VERSION 1.0.1)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/OscLib/CMakeLists.txt
+++ b/OscLib/CMakeLists.txt
@@ -14,6 +14,7 @@ cet_make_library(LIBRARY_NAME OscLib
   OscCalcDMP.cxx
   OscCalcDumb.cxx
   OscCalcGeneral.cxx
+  OscCalcNuFast.cxx
   OscCalcPMNS_CPT.cxx
   OscCalcPMNS_NSI.cxx
   OscCalcPMNS.cxx


### PR DESCRIPTION
the `OscCalcNuFast` class added in #24 wasn't included in the list of targets in `CMakeLists.txt`, so this PR adds it. i also bump the CMake version to 1.0.1, so we can cut a new version immediately when this PR is merged.