### PR TITLE
Feature/osccalc sterile eigen cacheresults

### DIFF
--- a/OscLib/Cache.h
+++ b/OscLib/Cache.h
@@ -88,8 +88,6 @@ namespace analytic {
   };
 
   template<class KT, class VT> class ProbCache : public std::unordered_map<KT, Probs<VT>> {};
-
-
 }
 }
 

--- a/OscLib/Cache.h
+++ b/OscLib/Cache.h
@@ -4,6 +4,7 @@
 
 #include <unordered_map>
 #include <Eigen/Eigen>
+#include <iostream> 
 
 // We want to put ArrayXd into an unordered_map, so define hash and equality
 namespace std
@@ -63,23 +64,19 @@ namespace analytic {
     }
 
     inline __attribute__((always_inline)) T P(int from, int to) const {
-      // convert flavours to indices into matrix
-      const int i0 = (from-12)/2;
-      const int i1 = to == 0 ? 4 : (to-12)/2;
-
-      switch(i0*3+i1){
-      case 0: return Pee;
-      case 1: return Pme;
-      case 2: return Pte;
-      case 3: return Pem;
-      case 4: return Pmm;
-      case 5: return Ptm;
-      case 6: return Pet;
-      case 7: return Pmt;
-      case 8: return Ptt;
-      case 9: return Pes;
-      case 10: return Pms;
-      case 11: return Pts;
+      switch(from*100+to){
+      case 1212: return Pee;
+      case 1412: return Pme;
+      case 1612: return Pte;
+      case 1214: return Pem;
+      case 1414: return Pmm;
+      case 1614: return Ptm;
+      case 1216: return Pet;
+      case 1416: return Pmt;
+      case 1616: return Ptt;
+      case 1200: return Pes;
+      case 1400: return Pms;
+      case 1600: return Pts;
       default: abort();
       }
     }

--- a/OscLib/Cache.h
+++ b/OscLib/Cache.h
@@ -65,7 +65,7 @@ namespace analytic {
     inline __attribute__((always_inline)) T P(int from, int to) const {
       // convert flavours to indices into matrix
       const int i0 = (from-12)/2;
-      const int i1 = to = 0 ? 4 : (to-12)/2;
+      const int i1 = to == 0 ? 4 : (to-12)/2;
 
       switch(i0*3+i1){
       case 0: return Pee;

--- a/OscLib/Cache.h
+++ b/OscLib/Cache.h
@@ -57,11 +57,9 @@ namespace analytic {
           T et, T mt, T tt)
       : Pee(ee), Pme(me), Pte(te), Pem(em), Pmm(mm), Ptm(tm), Pet(et), Pmt(mt), Ptt(tt)
     {
-      // exploit 4f unitarity
-      // we do not need to account for Pse, Psm, Pst, "from" is never allowed to be sterile
-      Pes = 1-Pee-Pem-Pet;
-      Pms = 1-Pme-Pmm-Pmt;
-      Pts = 1-Pte-Ptm-Pts;
+      Pes = Pee+Pem+Pet;
+      Pms = Pme+Pmm+Pmt;
+      Pts = Pte+Ptm+Ptt;
     }
 
     inline __attribute__((always_inline)) T P(int from, int to) const {
@@ -88,7 +86,7 @@ namespace analytic {
 
   protected:
     T Pee, Pme, Pte, Pem, Pmm, Ptm, Pet, Pmt, Ptt;
-    T Pes, Pms, Pts; //
+    T Pes, Pms, Pts; // osc probability to active states
 
   };
 

--- a/OscLib/Cache.h
+++ b/OscLib/Cache.h
@@ -41,33 +41,60 @@ namespace analytic {
     Probs(T ee, T me, T em, T mm)
       : Pee(ee), Pme(me), Pem(em), Pmm(mm)
     {
+      // exploit 3f unitarity
+      Pte = 1-Pee-Pme;
+      Ptm = 1-Pem-Pmm;
+      Pet = 1-Pee-Pem;
+      Pmt = 1-Pme-Pmm;
+      Ptt = Pee+Pem+Pme+Pmm-1;
+      Pes = 0;
+      Pms = 0;
+      Pts = 0;
+    }
+
+    Probs(T ee, T me, T te,
+          T em, T mm, T tm,
+          T et, T mt, T tt)
+      : Pee(ee), Pme(me), Pte(te), Pem(em), Pmm(mm), Ptm(tm), Pet(et), Pmt(mt), Ptt(tt)
+    {
+      // exploit 4f unitarity
+      // we do not need to account for Pse, Psm, Pst, "from" is never allowed to be sterile
+      Pes = 1-Pee-Pem-Pet;
+      Pms = 1-Pme-Pmm-Pmt;
+      Pts = 1-Pte-Ptm-Pts;
     }
 
     inline __attribute__((always_inline)) T P(int from, int to) const {
       // convert flavours to indices into matrix
       const int i0 = (from-12)/2;
-      const int i1 = (to-12)/2;
+      const int i1 = to = 0 ? 4 : (to-12)/2;
 
-      // Exploit unitarity
       switch(i0*3+i1){
       case 0: return Pee;
       case 1: return Pme;
-      case 2: return 1-Pee-Pme; // Pte
+      case 2: return Pte;
       case 3: return Pem;
       case 4: return Pmm;
-      case 5: return 1-Pem-Pmm; // Ptm
-      case 6: return 1-Pee-Pem; // Pet
-      case 7: return 1-Pme-Pmm; // Pmt
-      case 8: return Pee+Pem+Pme+Pmm-1; // Ptt
+      case 5: return Ptm;
+      case 6: return Pet;
+      case 7: return Pmt;
+      case 8: return Ptt;
+      case 9: return Pes;
+      case 10: return Pms;
+      case 11: return Pts;
       default: abort();
       }
     }
 
   protected:
-    T Pee, Pme, Pem, Pmm;
+    T Pee, Pme, Pte, Pem, Pmm, Ptm, Pet, Pmt, Ptt;
+    T Pes, Pms, Pts; //
+
   };
-  
+
   template<class KT, class VT> class ProbCache : public std::unordered_map<KT, Probs<VT>> {};
+
+
 }
 }
 

--- a/OscLib/OscCalcSterileEigen.cxx
+++ b/OscLib/OscCalcSterileEigen.cxx
@@ -65,6 +65,7 @@ namespace osc
   //---------------------------------------------------------------------------
   void OscCalcSterileEigen::SetStdPars()
   {
+
     this->InitializeVectors();
 
     if(fNumNus>2) {
@@ -78,11 +79,13 @@ namespace osc
       this->SetAngle(1,2,0.7);
       this->SetDm(2,2.4e-3);
     }
+
   }
 
   //--------------------------------------------------------------------------- 
   void OscCalcSterileEigen::SetAngle(int i, int j, double th) 
   {
+
     if (i > j) {
       cout << "First argument should be smaller than second argument" << endl;
       cout << "Setting reverse order (Theta" << j << i << "). " << endl;
@@ -105,6 +108,7 @@ namespace osc
   //---------------------------------------------------------------------------
   void OscCalcSterileEigen::SetDelta(int i, int j, double delta) 
   {
+
     if(i>j){
       cout << "First argument should be smaller than second argument" << endl;
       cout << "Setting reverse order (Delta" << j << i << "). " << endl;
@@ -298,6 +302,7 @@ namespace osc
   //---------------------------------------------------------------------------
   void OscCalcSterileEigen::SolveHam(double E, double Ne, int anti)
   {
+
     // Check if anything has changed before recalculating
     if(Ne!=fCachedNe || E!=fCachedE || anti!=fCachedAnti || !fBuiltHms ){
       fCachedNe = Ne;
@@ -342,7 +347,6 @@ namespace osc
     fNuState = fEig.eigenvectors()*(
   				  fEig.eigenvalues().unaryExpr([L] (double x) { double sinx(0), cosx(0); _sincos(-constants::kkmTom/constants::kInversemToeV*L*x,sinx,cosx); return complex(cosx, sinx);}
   				  ).asDiagonal())*fEig.eigenvectors().adjoint()*fNuState;
-
   }
 
   //---------------------------------------------------------------------------
@@ -358,7 +362,6 @@ namespace osc
     for (; Li!=Lend; ++Li, ++Ni) {
       this->PropMatter(*Li, E, *Ni, anti);
     }
-
   }
 
   //---------------------------------------------------------------------------

--- a/OscLib/OscCalcSterileEigen.cxx
+++ b/OscLib/OscCalcSterileEigen.cxx
@@ -365,7 +365,7 @@ namespace osc
   double OscCalcSterileEigen::GetP(int from, int to) const
   {
     assert(to >= 0 && to < fNumNus);
-    return norm(fNuState.coeff(from,to));
+    return norm(fNuState.coeff(to,from));
   }
 
   //---------------------------------------------------------------------------

--- a/OscLib/OscCalcSterileEigen.h
+++ b/OscLib/OscCalcSterileEigen.h
@@ -83,14 +83,10 @@ namespace osc
               const std::list<double>& Ne,
               int anti);
     
-    /// Return the probability of final state in flavour flv
-    /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
-    virtual double GetP(int flv) const;
-    
-    /// Erase memory of neutrino propagate and reset neutrino
-    /// to pure flavour flv. Preserves values of mixing and mass-splittings
-    /// @param flv - final flavor (0,1,2) = (nue,numu,nutau)
-    virtual void ResetToFlavour(int flv=1);
+    /// Return the probability of final state in flavour to
+    /// @param from - startging flavor (0,1,2) = (nue,numu,nutau)
+    /// @param to - final flavor (0,1,2) = (nue,numu,nutau)
+    virtual double GetP(int from, int to) const;
     
     int fNumNus;
 
@@ -102,7 +98,7 @@ namespace osc
     Eigen::Vector4d  fDm;      ///< m^2_i - m^2_1 in vacuum
     Eigen::Matrix4d  fTheta;   ///< theta[i][j] mixing angle
     Eigen::Matrix4d  fDelta;   ///< delta[i][j] CP violating phase
-    Eigen::Vector4cd  fNuState; ///< The neutrino current state
+    Eigen::Matrix4cd  fNuState; ///< allowed initial neutrino states
     Eigen::Matrix4cd  fHms;     ///< matrix H*2E in eV^2
     Eigen::Matrix4cd  fHmsMat;  ///< matrix H*2E in eV^2, with matter
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix4cd> fEig;  ///< eigen solver

--- a/OscLib/OscCalcSterileEigen.h
+++ b/OscLib/OscCalcSterileEigen.h
@@ -29,7 +29,6 @@ namespace osc
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     using IOscCalcAdjustable::P;
-
     OscCalcSterileEigen();
     OscCalcSterileEigen(const OscCalcSterileEigen& calc);
     virtual ~OscCalcSterileEigen();

--- a/OscLib/OscCalcSterileEigen.h
+++ b/OscLib/OscCalcSterileEigen.h
@@ -11,11 +11,16 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "OscLib/IOscCalcSterile.h"
+#include "OscLib/Cache.h"
 #include <Eigen/Dense>
 #include <list>
 
 namespace osc
 {
+
+  using analytic::ProbCache;
+  using analytic::Probs;
+
   /// \brief Eigen-based 3+1 sterile oscillation calculator
   ///
   /// Adapt the \ref PMNS_Sterile calculator to Eigen, hardcoded to 3+1
@@ -24,6 +29,7 @@ namespace osc
   public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     using IOscCalcAdjustable::P;
+
     OscCalcSterileEigen();
     OscCalcSterileEigen(const OscCalcSterileEigen& calc);
     virtual ~OscCalcSterileEigen();
@@ -84,9 +90,13 @@ namespace osc
               int anti);
     
     /// Return the probability of final state in flavour to
-    /// @param from - startging flavor (0,1,2) = (nue,numu,nutau)
+    /// @param from - starting flavor (0,1,2) = (nue,numu,nutau)
     /// @param to - final flavor (0,1,2) = (nue,numu,nutau)
     virtual double GetP(int from, int to) const;
+
+    /// Cache newly calculated probabilities to the cache
+    /// @param key - key calculated from ToKey * [-1,1] for [anu, nu]
+    virtual void CacheProbs(long key);
     
     int fNumNus;
 
@@ -102,6 +112,10 @@ namespace osc
     Eigen::Matrix4cd  fHms;     ///< matrix H*2E in eV^2
     Eigen::Matrix4cd  fHmsMat;  ///< matrix H*2E in eV^2, with matter
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix4cd> fEig;  ///< eigen solver
+
+    analytic::ProbCache<long,double> fCache;
+    inline void ClearProbCaches() { fCache.clear(); };
+    inline long ToKey(double E){ return (long)(E*1e6); };
 
   };
 


### PR DESCRIPTION
This updates OscCalcSterileEigen to be much faster. For NOvA stats-only fits using PISCES this is a >10x speedup, for stat+systs fits it is closer to a 3-4x speedup. Validation can be found on NOvA-DocDB-67750. 

----

Details:
* This changes how we calculate the oscillation probabilities, previously `fNuState` was a vector of pure nu_e, nu_mu, or nu_tau, which was then propagated through matter, it's now a 4x4 matrix with (1,1,1,0) on the diagonal so all flavors can be propagated at the same time. This could be a (3,4) matrix but in practice I don't think it matters. Realistically it could be a (2,4) if we wanted to just propagate nu_mu and nu_e, but wanted to keep nu_tau for generality. 
* We now make use of the cache that Cullen introduced to ensure we don't recalculate oscillation probabilities when we don't need to. We cache on energy in keV as a `long` with the sign being for nu/anu.

Using the Cache required some changes to the cache since it was set up only for 3F. 
* Added a 4F constructor so we don't disturb what was done previously
* I also modified the logic in the switch slightly to make it appropriate for use with steriles

----

Maybe a bug? I noticed that the way the cache was returning the probability before these changes wasn't doing what I expected, take _eg_ mu->e conversion, I would expect this to return `Pme`, but mu->e implies i0=1, i0=0, switch=3 -> `Pem` ie time reversed. This update fixes that - but let me know if I missed something subtle somewhere.


