### PR TITLE
Fix time reversal bug in OscCalcNuFast and OscCalcAnalytic

### DIFF
--- a/OscLib/Cache.h
+++ b/OscLib/Cache.h
@@ -36,6 +36,10 @@ namespace std
 namespace osc {
 namespace analytic {
   
+  /// Structure for holding together oscillation probabilities for the purpose of caching them.
+  /// This structure assumes unitarity for the 3F sector.
+  /// This structure is capable of holding probabilities of oscillation to sterile states.
+  /// Throughout this structure, "Pme" means "probability of a muon neutrino oscillating to an electron neutrino."  
   template<class T> class Probs
   {
   public:

--- a/OscLib/OscCalcAnalytic.cxx
+++ b/OscLib/OscCalcAnalytic.cxx
@@ -371,8 +371,8 @@ namespace osc::analytic
     const cmplx<VT> Aem = M.et*M.mt.conj() - M.em*M.tt;
 
     const Probs<VT> ps((Aee       *es.sume - (M.mm+M.tt) *es.sumxe + es.sumxxe).norm(),
-                       (Aem.conj()*es.sume +  M.em.conj()*es.sumxe            ).norm(),
                        (Aem       *es.sume +  M.em       *es.sumxe            ).norm(),
+                       (Aem.conj()*es.sume +  M.em.conj()*es.sumxe            ).norm(),
                        (Amm       *es.sume - (M.ee+M.tt) *es.sumxe + es.sumxxe).norm());
 
     ProbCache<KVT, VT>::emplace(E, ps);

--- a/OscLib/OscCalcNuFast.cxx
+++ b/OscLib/OscCalcNuFast.cxx
@@ -247,7 +247,7 @@ namespace osc {
         + Ue3sq * Ue2sq * sinsqD32_2);
     
     // Store the probabilities in the cache.
-    const analytic::Probs<VT> ps(Pee,Pme_CPC - Pme_CPV,Pme_CPC + Pme_CPV,Pmm);
+    const analytic::Probs<VT> ps(Pee,Pme_CPC + Pme_CPV,Pme_CPC - Pme_CPV,Pmm);
     analytic::ProbCache<KVT, VT>::emplace(E,ps);
     // Return the probability.
     return ps.P(from,to);


### PR DESCRIPTION
PR https://github.com/cafana/OscLib/pull/39 included a change in behavior to [Probs](https://github.com/cafana/OscLib/blob/31b94477c8af44af0afd6a190e3c556a31a70992/OscLib/Cache.h#L39), the cache internally used by [OscCalcNuFast](https://github.com/cafana/OscLib/blob/31b94477c8af44af0afd6a190e3c556a31a70992/OscLib/OscCalcNuFast.cxx#L250) and [OscCalcAnalytic](https://github.com/cafana/OscLib/blob/31b94477c8af44af0afd6a190e3c556a31a70992/OscLib/OscCalcAnalytic.cxx#L373) so that `OscCalcSterileEigen` could also use it. The PR also included a change that fixed an apparent time-reversal bug in the cache.

Recently, it was discovered that `OscCalcNuFast` and `OscCalcAnalytic` were misbehaving, and we traced the issue to swapped mu->e and e->mu predictions because of this change. What I think happened is that the old form of `Probs` wasn't time-reversal bugged but instead used a naming convention that's unintuitive. Intuitive and current convention: "Pme" means "probability of numu oscillating into nue." Unintuitive old convention: "Pme" means "probability of numu oscillating _from_ nue."

This PR adds comments to `Probs` to make the current intuitive convention unambiguous and also swaps the mu->e and e->mu channels in `OscCalcNuFast` and `OscCalcAnalytic` to fix the current time-reversal bug. In my local testing, the calculators behave correctly now.